### PR TITLE
Make sure that execute_script returns a value

### DIFF
--- a/browser_spec.rb
+++ b/browser_spec.rb
@@ -130,6 +130,10 @@ describe "Browser" do
       browser.execute_script("document.getElementById('rspec').innerHTML = 'javascript text'")
       browser.pre(:id, 'rspec').text.should == "javascript text"
     end
+    it "should return value after executing the script" do
+      browser.execute_script("2+2").to_i.should == 4
+      browser.execute_script("null").should == nil
+    end
   end
 
   describe "#back and #forward" do


### PR DESCRIPTION
Some implementations of watir  uses dom api execScript() in case if eval() is not available , unfortunately execScrtipt() executes the js code but does not return a value. I saw this problem with watir on IE 9 (IE9 OLE interface does not support eval()). This test is to protect such situation  
