### PR TITLE
Browser html

### DIFF
--- a/browser_spec.rb
+++ b/browser_spec.rb
@@ -26,7 +26,9 @@ describe "Browser" do
         html = browser.html.downcase # varies between browsers
 
         html.should =~ /^<html/
-        html.should include('<meta content="text/html; charset=utf-8" http-equiv="content-type" />')
+        html.should include('<meta ')
+        html.should include(' content="text/html; charset=utf-8"')
+        html.should include(' http-equiv="content-type"')
       end
     end
 


### PR DESCRIPTION
changed spec so it works with safariwatir, spec was expecting

```
<meta content="text/html; charset=utf-8" http-equiv="content-type" />
```

but in Safari it was

```
<meta http-equiv="Content-type" content="text/html; charset=utf-8">
```

I am not sure why are you checking `meta` tag, so I made the smallest possible change.
