### PR TITLE
Goto fix

### DIFF
--- a/browser_spec.rb
+++ b/browser_spec.rb
@@ -124,6 +124,28 @@ describe "Browser" do
       lambda { browser.goto("about:blank") }.should_not raise_error
     end
 
+    it "goes to a data URL scheme address without raising errors" do
+      lambda { browser.goto("data:text/html;content-type=utf-8,foobar") }.should_not raise_error
+    end
+
+    compliant_on :firefox do
+      it "goes to internal Firefox URL 'about:mozilla' without raising errors" do
+        lambda { browser.goto("about:mozilla") }.should_not raise_error
+      end
+    end
+
+    compliant_on :opera do
+      it "goes to internal Opera URL 'opera:config' without raising errors" do
+        lambda { browser.goto("opera:config") }.should_not raise_error
+      end
+    end
+
+    compliant_on :chrome do
+      it "goes to internal Chrome URL 'chrome://settings/browser' without raising errors" do
+        lambda { browser.goto("chrome://settings/browser") }.should_not raise_error
+      end
+    end
+
     it "updates the page when location is changed with setTimeout + window.location" do
       browser.goto(WatirSpec.files + "/timeout_window_location.html")
       sleep 1


### PR DESCRIPTION
Adding tests for change to Browser#goto that allows you to visit vendor-specific URLs and data URL scheme addresses
