### PR TITLE
This was the only file I could find that didn't use a string for the des...

### DIFF
--- a/textarea_spec.rb
+++ b/textarea_spec.rb
@@ -1,6 +1,6 @@
 require File.expand_path("../spec_helper", __FILE__)
 
-describe Watir::TextArea do
+describe "TextArea" do
   before :each do
     browser.goto WatirSpec.url_for('forms_with_input_elements.html')
   end


### PR DESCRIPTION
...cription, and it caused:

> uninitialized constant Watir::TextArea (NameError)

I changed it and it fixes the error for me, and it's consistent with the rest of the code.
