### PR TITLE
Spec on #flash, ensuring it returns the element on which it was called.

### DIFF
--- a/element_spec.rb
+++ b/element_spec.rb
@@ -262,4 +262,13 @@ describe "Element" do
       end
     end
   end
+
+  describe "#flash" do
+
+    let(:h2) { browser.h2(:text => 'Add user') }
+
+    it 'returns the element on which it was called' do
+      h2.flash.should == h2
+    end
+  end
 end


### PR DESCRIPTION
This aids in chainability, eg:

```
browser.link(:text => "Click here").flash.click
```

Instead of having to do something like this:

```
browser.link(:text => "Click here").tap(&:flash).click
```
