### PR TITLE
Change from RSpect should syntax to expect syntax.

### DIFF
--- a/alert_spec.rb
+++ b/alert_spec.rb
@@ -21,13 +21,13 @@ describe 'Alert API' do
             browser.button(:id => 'alert').click_no_wait
           end
 
-          browser.alert.text.should include('ok')
+          expect(browser.alert.text).to include('ok')
         end
       end
 
       describe '#exists?' do
         it 'returns false if alert is not present' do
-          browser.alert.should_not exist
+          expect(browser.alert).to_not exist
         end
 
         it 'returns true if alert is present' do
@@ -54,7 +54,7 @@ describe 'Alert API' do
           end
 
           browser.alert.ok
-          browser.alert.should_not exist
+          expect(browser.alert).to_not exist
         end
       end
 
@@ -69,7 +69,7 @@ describe 'Alert API' do
           end
 
           browser.alert.when_present.close
-          browser.alert.should_not exist
+          expect(browser.alert).to_not exist
         end
       end
 
@@ -78,13 +78,13 @@ describe 'Alert API' do
           browser.button(:id => 'timeout-alert').click
           browser.alert.when_present.close
 
-          browser.alert.should_not exist
+          expect(browser.alert).to_not exist
         end
 
         it 'raises error if alert is not present after timeout' do
-          lambda {
+          expect{
             browser.alert.when_present(0.1).close
-          }.should raise_error(Watir::Wait::TimeoutError)
+          }.to raise_error(Watir::Wait::TimeoutError)
         end
       end
     end
@@ -101,7 +101,7 @@ describe 'Alert API' do
           end
 
           browser.alert.ok
-          browser.button(:id => 'confirm').value.should == "true"
+          expect(browser.button(:id => 'confirm').value).to eq "true"
         end
       end
 
@@ -116,7 +116,7 @@ describe 'Alert API' do
           end
 
           browser.alert.when_present.close
-          browser.button(:id => 'confirm').value.should == "false"
+          expect(browser.button(:id => 'confirm').value).to eq "false"
         end
       end
     end
@@ -134,7 +134,7 @@ describe 'Alert API' do
 
           browser.alert.set 'My Name'
           browser.alert.ok
-          browser.button(:id => 'prompt').value.should == 'My Name'
+          expect(browser.button(:id => 'prompt').value).to eq 'My Name'
         end
       end
     end

--- a/area_spec.rb
+++ b/area_spec.rb
@@ -10,67 +10,67 @@ describe "Area" do
   # Exists method
   describe "#exist?" do
     it "returns true if the area exists" do
-      browser.area(:id, "NCE").should exist
-      browser.area(:id, /NCE/).should exist
-      browser.area(:title, "Tables").should exist
-      browser.area(:title, /Tables/).should exist
+      expect(browser.area(:id, "NCE")).to exist
+      expect(browser.area(:id, /NCE/)).to exist
+      expect(browser.area(:title, "Tables")).to exist
+      expect(browser.area(:title, /Tables/)).to exist
 
       not_compliant_on :internet_explorer do
-        browser.area(:href, "tables.html").should exist
+        expect(browser.area(:href, "tables.html")).to exist
       end
 
-      browser.area(:href, /tables/).should exist
+      expect(browser.area(:href, /tables/)).to exist
 
-      browser.area(:index, 0).should exist
-      browser.area(:xpath, "//area[@id='NCE']").should exist
+      expect(browser.area(:index, 0)).to exist
+      expect(browser.area(:xpath, "//area[@id='NCE']")).to exist
     end
 
     it "returns the first area if given no args" do
-      browser.area.should exist
+      expect(browser.area).to exist
     end
 
     it "returns false if the area doesn't exist" do
-      browser.area(:id, "no_such_id").should_not exist
-      browser.area(:id, /no_such_id/).should_not exist
-      browser.area(:title, "no_such_title").should_not exist
-      browser.area(:title, /no_such_title/).should_not exist
+      expect(browser.area(:id, "no_such_id")).to_not exist
+      expect(browser.area(:id, /no_such_id/)).to_not exist
+      expect(browser.area(:title, "no_such_title")).to_not exist
+      expect(browser.area(:title, /no_such_title/)).to_not exist
 
-      browser.area(:href, "no-tables.html").should_not exist
-      browser.area(:href, /no-tables/).should_not exist
+      expect(browser.area(:href, "no-tables.html")).to_not exist
+      expect(browser.area(:href, /no-tables/)).to_not exist
 
-      browser.area(:index, 1337).should_not exist
-      browser.area(:xpath, "//area[@id='no_such_id']").should_not exist
+      expect(browser.area(:index, 1337)).to_not exist
+      expect(browser.area(:xpath, "//area[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.area(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.area(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.area(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.area(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Attribute methods
   describe "#id" do
     it "returns the id attribute" do
-      browser.area(:index, 0).id.should == "NCE"
+      expect(browser.area(:index, 0).id).to eq "NCE"
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.area(:index, 2).id.should == ''
+      expect(browser.area(:index, 2).id).to eq ''
     end
 
     it "raises UnknownObjectException if the area doesn't exist" do
-      lambda { browser.area(:id, "no_such_id").id }.should raise_error(UnknownObjectException)
-      lambda { browser.area(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{ browser.area(:id, "no_such_id").id }.to raise_error(UnknownObjectException)
+      expect{ browser.area(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
 
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.area(:index, 0).should respond_to(:id)
+      expect(browser.area(:index, 0)).to respond_to(:id)
     end
   end
 

--- a/areas_spec.rb
+++ b/areas_spec.rb
@@ -10,20 +10,20 @@ describe "Areas" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.areas(:alt => "Tables").to_a.should == [browser.area(:alt => "Tables")]
+        expect(browser.areas(:alt => "Tables").to_a).to eq [browser.area(:alt => "Tables")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the number of areas" do
-      browser.areas.length.should == 3
+      expect(browser.areas.length).to eq 3
     end
   end
 
   describe "#[]" do
     it "returns the area at the given index" do
-      browser.areas[0].id.should == "NCE"
+      expect(browser.areas[0].id).to eq("NCE")
     end
   end
 
@@ -32,13 +32,13 @@ describe "Areas" do
       count = 0
 
       browser.areas.each_with_index do |a, index|
-        a.id.should == browser.area(:index, index).id
-        a.title.should == browser.area(:index, index).title
+        expect(a.id).to eq browser.area(:index, index).id
+        expect(a.title).to eq browser.area(:index, index).title
 
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/browser_spec.rb
+++ b/browser_spec.rb
@@ -6,14 +6,14 @@ describe "Browser" do
   describe "#exists?" do
     it "returns true if we are at a page" do
       browser.goto(WatirSpec.url_for("non_control_elements.html"))
-      browser.should exist
+      expect(browser).to exist
     end
 
     not_compliant_on(:safariwatir) do
       it "returns false after Browser#close" do
         b = WatirSpec.new_browser
         b.close
-        b.should_not exist
+        expect(b).to_not exist
       end
     end
   end
@@ -24,21 +24,21 @@ describe "Browser" do
       browser.goto(WatirSpec.url_for("right_click.html"))
       html = browser.html.downcase # varies between browsers
 
-      html.should =~ /^<html/
-      html.should include('<meta ')
-      html.should include(' content="text/html; charset=utf-8"')
+      expect(html).to match(/^<html/)
+      expect(html).to include('<meta ')
+      expect(html).to include(' content="text/html; charset=utf-8"')
 
       not_compliant_on :internet_explorer do
-        html.should include(' http-equiv="content-type"')
+        expect(html).to include(' http-equiv="content-type"')
       end
 
       deviates_on :internet_explorer9, :internet_explorer10 do
-        html.should include(' http-equiv="content-type"')
+        expect(html).to include(' http-equiv="content-type"')
       end
 
       not_compliant_on :internet_explorer9, :internet_explorer10 do
         deviates_on :internet_explorer do
-          html.should include(' http-equiv=content-type')
+          expect(html).to include(' http-equiv=content-type')
         end
       end
     end
@@ -47,7 +47,7 @@ describe "Browser" do
   describe "#title" do
     it "returns the current page title" do
       browser.goto(WatirSpec.url_for("non_control_elements.html"))
-      browser.title.should == "Non-control elements"
+      expect(browser.title).to eq "Non-control elements"
     end
   end
 
@@ -62,7 +62,7 @@ describe "Browser" do
         browser.goto(WatirSpec.url_for("non_control_elements.html"))
 
         browser.execute_script "window.status = 'All done!';"
-        browser.status.should == "All done!"
+        expect(browser.status).to eq "All done!"
       end
     end
   end
@@ -70,15 +70,15 @@ describe "Browser" do
   describe "#name" do
     it "returns browser name" do
       not_compliant_on :watir_classic, [:webdriver, :phantomjs] do
-        browser.name.should == WatirSpec.implementation.browser_args[0]
+        expect(browser.name).to eq WatirSpec.implementation.browser_args[0]
       end
 
       deviates_on [:webdriver, :phantomjs] do
-        browser.name.should be_an_instance_of(Symbol)
+        expect(browser.name).to be_an_instance_of(Symbol)
       end
 
       deviates_on :watir_classic do
-        browser.name.should == :internet_explorer
+        expect(browser.name).to eq :internet_explorer
       end
     end
   end
@@ -86,40 +86,40 @@ describe "Browser" do
   describe "#text" do
     it "returns the text of the page" do
       browser.goto(WatirSpec.url_for("non_control_elements.html"))
-      browser.text.should include("Dubito, ergo cogito, ergo sum.")
+      expect(browser.text).to include("Dubito, ergo cogito, ergo sum.")
     end
 
     it "returns the text also if the content-type is text/plain" do
       # more specs for text/plain? what happens if we call other methods?
       browser.goto(WatirSpec.url_for("plain_text", :needs_server => true))
-      browser.text.strip.should == 'This is text/plain'
+      expect(browser.text.strip).to eq 'This is text/plain'
     end
   end
 
   describe "#url" do
     it "returns the current url" do
       browser.goto(WatirSpec.url_for("non_control_elements.html", :needs_server => true))
-      browser.url.should == WatirSpec.url_for("non_control_elements.html", :needs_server => true)
+      expect(browser.url).to eq WatirSpec.url_for("non_control_elements.html", :needs_server => true)
     end
 
     it "always returns top url" do
       browser.goto(WatirSpec.url_for("frames.html", :needs_server => true))
       browser.frame.body.exists? # switches to frame
-      browser.url.should == WatirSpec.url_for("frames.html", :needs_server => true)
+      expect(browser.url).to eq WatirSpec.url_for("frames.html", :needs_server => true)
     end
   end
 
   describe "#title" do
     it "returns the current title" do
       browser.goto(WatirSpec.url_for("non_control_elements.html", :needs_server => true))
-      browser.title.should == "Non-control elements"
+      expect(browser.title).to eq "Non-control elements"
     end
 
     it "always returns top title" do
       browser.goto(WatirSpec.url_for("frames.html", :needs_server => true))
       title = browser.element(:tag_name => 'title').text
       browser.frame.body.exists? # switches to frame
-      browser.title.should == "Frames"
+      expect(browser.title).to eq "Frames"
     end
   end
 
@@ -129,8 +129,8 @@ describe "Browser" do
         url = WatirSpec.url_for("non_control_elements.html")
         browser = WatirSpec.implementation.browser_class.start(WatirSpec.url_for("non_control_elements.html"))
 
-        browser.should be_instance_of(WatirSpec.implementation.browser_class)
-        browser.title.should == "Non-control elements"
+        expect(browser).to be_instance_of(WatirSpec.implementation.browser_class)
+        expect(browser.title).to eq "Non-control elements"
         browser.close
       end
     }
@@ -141,8 +141,8 @@ describe "Browser" do
         driver, args = WatirSpec.implementation.browser_args
         browser = Watir::Browser.start(WatirSpec.url_for("non_control_elements.html"), driver, args)
 
-        browser.should be_instance_of(Watir::Browser)
-        browser.title.should == "Non-control elements"
+        expect(browser).to be_instance_of(Watir::Browser)
+        expect(browser.title).to eq "Non-control elements"
         browser.close
       end
     }
@@ -152,48 +152,49 @@ describe "Browser" do
     not_compliant_on [:webdriver, :internet_explorer] do
       it "adds http:// to URLs with no URL scheme specified" do
         url = WatirSpec.host[%r{http://(.*)}, 1]
-        url.should_not be_nil
+        expect(url).to_not be_nil
         browser.goto(url)
-        browser.url.should =~ %r[http://#{url}/?]
+        #expect(browser.url).to =~ %r[http://#{url}/?]
+        expect(browser.url).to match(%r[http://#{url}/?])
       end
     end
 
     it "goes to the given url without raising errors" do
-      lambda { browser.goto(WatirSpec.url_for("non_control_elements.html")) }.should_not raise_error
+      expect{ browser.goto(WatirSpec.url_for("non_control_elements.html")) }.to_not raise_error
     end
 
     it "goes to the url 'about:blank' without raising errors" do
-      lambda { browser.goto("about:blank") }.should_not raise_error
+      expect{ browser.goto("about:blank") }.to_not raise_error
     end
 
     not_compliant_on :internet_explorer, [:webdriver, :safari] do
       it "goes to a data URL scheme address without raising errors" do
-        lambda { browser.goto("data:text/html;content-type=utf-8,foobar") }.should_not raise_error
+        expect{ browser.goto("data:text/html;content-type=utf-8,foobar") }.to_not raise_error
       end
     end
 
     compliant_on :firefox do
       it "goes to internal Firefox URL 'about:mozilla' without raising errors" do
-        lambda { browser.goto("about:mozilla") }.should_not raise_error
+        expect{ browser.goto("about:mozilla") }.to_not raise_error
       end
     end
 
     compliant_on :opera do
       it "goes to internal Opera URL 'opera:config' without raising errors" do
-        lambda { browser.goto("opera:config") }.should_not raise_error
+        expect{ browser.goto("opera:config") }.to_not raise_error
       end
     end
 
     compliant_on :chrome do
       it "goes to internal Chrome URL 'chrome://settings/browser' without raising errors" do
-        lambda { browser.goto("chrome://settings/browser") }.should_not raise_error
+        expect{ browser.goto("chrome://settings/browser") }.to_not raise_error
       end
     end
 
     it "updates the page when location is changed with setTimeout + window.location" do
       browser.goto(WatirSpec.url_for("timeout_window_location.html"))
       sleep 1
-      browser.url.should include("non_control_elements.html")
+      expect(browser.url).to include("non_control_elements.html")
     end
   end
 
@@ -201,9 +202,9 @@ describe "Browser" do
     it "refreshes the page" do
       browser.goto(WatirSpec.url_for("non_control_elements.html"))
       browser.span(:class, 'footer').click
-      browser.span(:class, 'footer').text.should include('Javascript')
+      expect(browser.span(:class, 'footer').text).to include('Javascript')
       browser.refresh
-      browser.span(:class, 'footer').text.should_not include('Javascript')
+      expect(browser.span(:class, 'footer').text).to_not include('Javascript')
     end
   end
 
@@ -211,37 +212,37 @@ describe "Browser" do
     before { browser.goto(WatirSpec.url_for("non_control_elements.html")) }
 
     it "executes the given JavaScript on the current page" do
-      browser.pre(:id, 'rspec').text.should_not == "javascript text"
+      expect(browser.pre(:id, 'rspec').text).to_not eq "javascript text"
       browser.execute_script("document.getElementById('rspec').innerHTML = 'javascript text'")
-      browser.pre(:id, 'rspec').text.should == "javascript text"
+      expect(browser.pre(:id, 'rspec').text).to eq "javascript text"
     end
 
     it "executes the given JavaScript in the context of an anonymous function" do
-      browser.execute_script("1 + 1").should be_nil
-      browser.execute_script("return 1 + 1").should == 2
+      expect(browser.execute_script("1 + 1")).to be_nil
+      expect(browser.execute_script("return 1 + 1")).to eq 2
     end
 
     it "returns correct Ruby objects" do
-      browser.execute_script("return {a: 1, \"b\": 2}").should == {"a" => 1, "b" => 2}
-      browser.execute_script("return [1, 2, \"3\"]").should == [1, 2, "3"]
-      browser.execute_script("return 1.2 + 1.3").should == 2.5
-      browser.execute_script("return 2 + 2").should == 4
-      browser.execute_script("return \"hello\"").should == "hello"
-      browser.execute_script("return").should be_nil
-      browser.execute_script("return null").should be_nil
-      browser.execute_script("return undefined").should be_nil
-      browser.execute_script("return true").should be_true
-      browser.execute_script("return false").should be_false
+      expect(browser.execute_script("return {a: 1, \"b\": 2}")).to eq Hash["a" => 1, "b" => 2]
+      expect(browser.execute_script("return [1, 2, \"3\"]")).to match_array([1, 2, "3"])
+      expect(browser.execute_script("return 1.2 + 1.3")).to eq 2.5
+      expect(browser.execute_script("return 2 + 2")).to eq 4
+      expect(browser.execute_script("return \"hello\"")).to eq "hello"
+      expect(browser.execute_script("return")).to be_nil
+      expect(browser.execute_script("return null")).to be_nil
+      expect(browser.execute_script("return undefined")).to be_nil
+      expect(browser.execute_script("return true")).to be_true
+      expect(browser.execute_script("return false")).to be_false
     end
 
     it "works correctly with multi-line strings and special characters" do
-     browser.execute_script("//multiline rocks!
+      expect(browser.execute_script("//multiline rocks!
                             var a = 22; // comment on same line
                             /* more
                             comments */
                             var b = '33';
                             var c = \"44\";
-                            return a + b + c").should == "223344"
+                            return a + b + c")).to eq "223344"
     end
   end
 
@@ -251,9 +252,9 @@ describe "Browser" do
       orig_url = browser.url
       browser.goto(WatirSpec.url_for("tables.html", :needs_server => true))
       new_url = browser.url
-      orig_url.should_not == new_url
+      expect(orig_url).to_not eq new_url
       browser.back
-      orig_url.should == browser.url
+      expect(orig_url).to eq browser.url
     end
 
     it "goes to the next page" do
@@ -264,9 +265,9 @@ describe "Browser" do
       urls << browser.url
 
       browser.back
-      browser.url.should == urls.first
+      expect(browser.url).to eq urls.first
       browser.forward
-      browser.url.should == urls.last
+      expect(browser.url).to eq urls.last
     end
 
     it "navigates between several history items" do
@@ -280,15 +281,15 @@ describe "Browser" do
       end
 
       3.times { browser.back }
-      browser.url.should == urls.first
+      expect(browser.url).to eq urls.first
       2.times { browser.forward }
-      browser.url.should == urls[2]
+      expect(browser.url).to eq urls[2]
     end
   end
 
   describe "#add_checker" do
     it "raises ArgumentError when not given any arguments" do
-      lambda { browser.add_checker }.should raise_error(ArgumentError)
+      expect{ browser.add_checker }.to raise_error(ArgumentError)
     end
 
     it "runs the given proc on each page load" do
@@ -299,7 +300,7 @@ describe "Browser" do
         browser.add_checker(proc)
         browser.goto(WatirSpec.url_for("non_control_elements.html"))
 
-        output.should include('Dubito, ergo cogito, ergo sum')
+        expect(output).to include('Dubito, ergo cogito, ergo sum')
       ensure
         browser.disable_checker(proc)
       end
@@ -309,21 +310,21 @@ describe "Browser" do
   describe "#disable_checker" do
     it "removes a previously added checker" do
       output = ''
-      checker = lambda { |browser| output << browser.text }
+      checker = lambda{ |browser| output << browser.text }
 
       browser.add_checker(checker)
       browser.goto(WatirSpec.url_for("non_control_elements.html"))
-      output.should include('Dubito, ergo cogito, ergo sum')
+      expect(output).to include('Dubito, ergo cogito, ergo sum')
 
       browser.disable_checker(checker)
       browser.goto(WatirSpec.url_for("definition_lists.html"))
-      output.should_not include('definition_lists')
+      expect(output).to_not include('definition_lists')
     end
   end
 
   it "raises UnknownObjectException when trying to access DOM elements on plain/text-page" do
     browser.goto(WatirSpec.url_for("plain_text", :needs_server => true))
-    lambda { browser.div(:id, 'foo').id }.should raise_error(UnknownObjectException)
+    expect{ browser.div(:id, 'foo').id }.to raise_error(UnknownObjectException)
   end
 
 end

--- a/button_spec.rb
+++ b/button_spec.rb
@@ -10,123 +10,123 @@ describe "Button" do
   # Exists method
   describe "#exists?" do
     it "returns true if the button exists (tag = :input)" do
-      browser.button(:id, "new_user_submit").should exist
-      browser.button(:id, /new_user_submit/).should exist
-      browser.button(:name, "new_user_reset").should exist
-      browser.button(:name, /new_user_reset/).should exist
-      browser.button(:value, "Button").should exist
-      browser.button(:value, /Button/).should exist
+      expect(browser.button(:id, "new_user_submit")).to exist
+      expect(browser.button(:id, /new_user_submit/)).to exist
+      expect(browser.button(:name, "new_user_reset")).to exist
+      expect(browser.button(:name, /new_user_reset/)).to exist
+      expect(browser.button(:value, "Button")).to exist
+      expect(browser.button(:value, /Button/)).to exist
       not_compliant_on :internet_explorer do
-        browser.button(:src, "images/button.png").should exist
+        expect(browser.button(:src, "images/button.png")).to exist
       end
-      browser.button(:src, /button\.png/).should exist
-      browser.button(:text, "Button 2").should exist
-      browser.button(:text, /Button 2/).should exist
-      browser.button(:class, "image").should exist
-      browser.button(:class, /image/).should exist
-      browser.button(:index, 0).should exist
-      browser.button(:xpath, "//input[@id='new_user_submit']").should exist
-      browser.button(:alt, "Create a new user").should exist
-      browser.button(:alt, /Create a/).should exist
+      expect(browser.button(:src, /button\.png/)).to exist
+      expect(browser.button(:text, "Button 2")).to exist
+      expect(browser.button(:text, /Button 2/)).to exist
+      expect(browser.button(:class, "image")).to exist
+      expect(browser.button(:class, /image/)).to exist
+      expect(browser.button(:index, 0)).to exist
+      expect(browser.button(:xpath, "//input[@id='new_user_submit']")).to exist
+      expect(browser.button(:alt, "Create a new user")).to exist
+      expect(browser.button(:alt, /Create a/)).to exist
     end
 
     it "returns true if the button exists (tag = :button)" do
-      browser.button(:name, "new_user_button_2").should exist
-      browser.button(:name, /new_user_button_2/).should exist
-      browser.button(:value, "button_2").should exist
-      browser.button(:value, /button_2/).should exist
-      browser.button(:text, 'Button 2').should exist
-      browser.button(:text, /Button 2/).should exist
+      expect(browser.button(:name, "new_user_button_2")).to exist
+      expect(browser.button(:name, /new_user_button_2/)).to exist
+      expect(browser.button(:value, "button_2")).to exist
+      expect(browser.button(:value, /button_2/)).to exist
+      expect(browser.button(:text, 'Button 2')).to exist
+      expect(browser.button(:text, /Button 2/)).to exist
     end
 
     it "returns true if the button exists (how = :caption)" do
-      browser.button(:caption, "Button 2").should exist
-      browser.button(:caption, /Button 2/).should exist
+      expect(browser.button(:caption, "Button 2")).to exist
+      expect(browser.button(:caption, /Button 2/)).to exist
     end
 
     it "returns the first button if given no args" do
-      browser.button.should exist
+      expect(browser.button).to exist
     end
 
     it "returns true for element with upper case type" do
-      browser.button(:id, "new_user_button_preview").should exist
+      expect(browser.button(:id, "new_user_button_preview")).to exist
     end
 
     it "returns false if the button doesn't exist" do
-      browser.button(:id, "no_such_id").should_not exist
-      browser.button(:id, /no_such_id/).should_not exist
-      browser.button(:name, "no_such_name").should_not exist
-      browser.button(:name, /no_such_name/).should_not exist
-      browser.button(:value, "no_such_value").should_not exist
-      browser.button(:value, /no_such_value/).should_not exist
-      browser.button(:src, "no_such_src").should_not exist
-      browser.button(:src, /no_such_src/).should_not exist
-      browser.button(:text, "no_such_text").should_not exist
-      browser.button(:text, /no_such_text/).should_not exist
-      browser.button(:class, "no_such_class").should_not exist
-      browser.button(:class, /no_such_class/).should_not exist
-      browser.button(:index, 1337).should_not exist
-      browser.button(:xpath, "//input[@id='no_such_id']").should_not exist
+      expect(browser.button(:id, "no_such_id")).to_not exist
+      expect(browser.button(:id, /no_such_id/)).to_not exist
+      expect(browser.button(:name, "no_such_name")).to_not exist
+      expect(browser.button(:name, /no_such_name/)).to_not exist
+      expect(browser.button(:value, "no_such_value")).to_not exist
+      expect(browser.button(:value, /no_such_value/)).to_not exist
+      expect(browser.button(:src, "no_such_src")).to_not exist
+      expect(browser.button(:src, /no_such_src/)).to_not exist
+      expect(browser.button(:text, "no_such_text")).to_not exist
+      expect(browser.button(:text, /no_such_text/)).to_not exist
+      expect(browser.button(:class, "no_such_class")).to_not exist
+      expect(browser.button(:class, /no_such_class/)).to_not exist
+      expect(browser.button(:index, 1337)).to_not exist
+      expect(browser.button(:xpath, "//input[@id='no_such_id']")).to_not exist
     end
 
     it "checks the tag name and type attribute when locating by xpath" do
-      browser.button(:xpath, "//input[@type='text']").should_not exist
-      browser.button(:xpath, "//input[@type='button']").should exist
+      expect(browser.button(:xpath, "//input[@type='text']")).to_not exist
+      expect(browser.button(:xpath, "//input[@type='button']")).to exist
     end
 
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.button(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.button(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.button(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.button(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Attribute methods
   describe "#class_name" do
     it "returns the class name of the button" do
-      browser.button(:name, "new_user_image").class_name.should == "image"
+      expect(browser.button(:name, "new_user_image").class_name).to eq "image"
     end
 
     it "returns an empty string if the button has no class name" do
-      browser.button(:name, "new_user_submit").class_name.should == ""
+      expect(browser.button(:name, "new_user_submit").class_name).to eq ""
     end
   end
 
   describe "#id" do
     it "returns the id if the button exists" do
-      browser.button(:index, 0).id.should == 'new_user_submit'
-      browser.button(:index, 1).id.should == 'new_user_reset'
-      browser.button(:index, 2).id.should == 'new_user_button'
+      expect(browser.button(:index, 0).id).to eq 'new_user_submit'
+      expect(browser.button(:index, 1).id).to eq 'new_user_reset'
+      expect(browser.button(:index, 2).id).to eq 'new_user_button'
     end
 
     it "raises UnknownObjectException if button does not exist" do
-      lambda { browser.button(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{ browser.button(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#name" do
     it "returns the name if button exists" do
-      browser.button(:index, 0).name.should == 'new_user_submit'
-      browser.button(:index, 1).name.should == 'new_user_reset'
-      browser.button(:index, 2).name.should == 'new_user_button'
+      expect(browser.button(:index, 0).name).to eq 'new_user_submit'
+      expect(browser.button(:index, 1).name).to eq 'new_user_reset'
+      expect(browser.button(:index, 2).name).to eq 'new_user_button'
     end
 
     it "raises UnknownObjectException if the button does not exist" do
-      lambda { browser.button(:name, "no_such_name").name }.should raise_error(UnknownObjectException)
+      expect{ browser.button(:name, "no_such_name").name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#src" do
     it "returns the src attribute for the button image" do
       # varies between browsers
-      browser.button(:name, "new_user_image").src.should include("images/button.png")
+      expect(browser.button(:name, "new_user_image").src).to include("images/button.png")
     end
 
     it "raises UnknownObjectException if the button does not exist" do
-      lambda { browser.button(:name, "no_such_name").src }.should raise_error(UnknownObjectException)
+      expect{ browser.button(:name, "no_such_name").src }.to raise_error(UnknownObjectException)
     end
   end
 
@@ -136,125 +136,125 @@ describe "Button" do
                     [:webdriver, :safari],
                     [:webdriver, :phantomjs] do
       it "returns the style attribute if the button exists" do
-        browser.button(:id, 'delete_user_submit').style.should == "border: 4px solid red;"
+        expect(browser.button(:id, 'delete_user_submit').style).to eq "border: 4px solid red;"
       end
     end
 
     deviates_on :internet_explorer8 do
       it "returns the style attribute if the button exists" do
-        browser.button(:id, 'delete_user_submit').style.should == "BORDER-BOTTOM: red 4px solid; BORDER-LEFT: red 4px solid; BORDER-TOP: red 4px solid; BORDER-RIGHT: red 4px solid"
+        expect(browser.button(:id, 'delete_user_submit').style).to eq "BORDER-BOTTOM: red 4px solid; BORDER-LEFT: red 4px solid; BORDER-TOP: red 4px solid; BORDER-RIGHT: red 4px solid"
       end
     end
     deviates_on :internet_explorer9 do
       it "returns the style attribute if the button exists" do
-        browser.button(:id, 'delete_user_submit').style.should == "border: 4px solid red;"
+        expect(browser.button(:id, 'delete_user_submit').style).to eq "border: 4px solid red;"
       end
     end
 
     deviates_on [:webdriver, :iphone], [:webdriver, :safari], [:webdriver, :phantomjs] do
       it "returns the style attribute if the button exists" do
         style = browser.button(:id, 'delete_user_submit').style
-        style.should include("border-top-width: 4px;")
-        style.should include("border-left-style: solid;")
-        style.should include("border-right-color: red;")
+        style.to include("border-top-width: 4px;")
+        style.to include("border-left-style: solid;")
+        style.to include("border-right-color: red;")
       end
     end
 
     it "returns an empty string if the element exists and the attribute doesn't exist" do
-      browser.button(:id, 'new_user_submit').style.should == ""
+      expect(browser.button(:id, 'new_user_submit').style).to eq ""
     end
 
     it "raises UnknownObjectException if the button does not exist" do
-      lambda { browser.button(:name, "no_such_name").style }.should raise_error(UnknownObjectException)
+      expect{ browser.button(:name, "no_such_name").style }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#title" do
     it "returns the title of the button" do
-      browser.button(:index, 0).title.should == 'Submit the form'
+      expect(browser.button(:index, 0).title).to eq 'Submit the form'
     end
 
     it "returns an empty string for button without title" do
-      browser.button(:index, 1).title.should == ''
+      expect(browser.button(:index, 1).title).to eq ''
     end
   end
 
   describe "#type" do
     it "returns the type if button exists" do
-      browser.button(:index, 0).type.should == 'submit'
-      browser.button(:index, 1).type.should == 'reset'
-      browser.button(:index, 2).type.should == 'button'
+      expect(browser.button(:index, 0).type).to eq 'submit'
+      expect(browser.button(:index, 1).type).to eq 'reset'
+      expect(browser.button(:index, 2).type).to eq 'button'
     end
 
     it "raises UnknownObjectException if button does not exist" do
-      lambda { browser.button(:name, "no_such_name").type }.should raise_error(UnknownObjectException)
+      expect{ browser.button(:name, "no_such_name").type }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#value" do
     it "returns the value if button exists" do
-      browser.button(:index, 0).value.should == 'Submit'
-      browser.button(:index, 1).value.should == 'Reset'
-      browser.button(:index, 2).value.should == 'Button'
+      expect(browser.button(:index, 0).value).to eq 'Submit'
+      expect(browser.button(:index, 1).value).to eq 'Reset'
+      expect(browser.button(:index, 2).value).to eq 'Button'
     end
 
     it "raises UnknownObjectException if button does not exist" do
-      lambda { browser.button(:name, "no_such_name").value }.should raise_error(UnknownObjectException)
+      expect{ browser.button(:name, "no_such_name").value }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#text" do
     it "returns the text of the button" do
-      browser.button(:index, 0).text.should == 'Submit'
-      browser.button(:index, 1).text.should == 'Reset'
-      browser.button(:index, 2).text.should == 'Button'
-      browser.button(:index, 3).text.should == 'Preview'
+      expect(browser.button(:index, 0).text).to eq 'Submit'
+      expect(browser.button(:index, 1).text).to eq 'Reset'
+      expect(browser.button(:index, 2).text).to eq 'Button'
+      expect(browser.button(:index, 3).text).to eq 'Preview'
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      lambda { browser.button(:id, "no_such_id").text }.should raise_error(UnknownObjectException)
+      expect{ browser.button(:id, "no_such_id").text }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.button(:index, 0).should respond_to(:class_name)
-      browser.button(:index, 0).should respond_to(:id)
-      browser.button(:index, 0).should respond_to(:name)
-      browser.button(:index, 0).should respond_to(:src)
-      browser.button(:index, 0).should respond_to(:style)
-      browser.button(:index, 0).should respond_to(:title)
-      browser.button(:index, 0).should respond_to(:type)
-      browser.button(:index, 0).should respond_to(:value)
+      expect(browser.button(:index, 0)).to respond_to(:class_name)
+      expect(browser.button(:index, 0)).to respond_to(:id)
+      expect(browser.button(:index, 0)).to respond_to(:name)
+      expect(browser.button(:index, 0)).to respond_to(:src)
+      expect(browser.button(:index, 0)).to respond_to(:style)
+      expect(browser.button(:index, 0)).to respond_to(:title)
+      expect(browser.button(:index, 0)).to respond_to(:type)
+      expect(browser.button(:index, 0)).to respond_to(:value)
     end
   end
 
   # Access methods
   describe "#enabled?" do
     it "returns true if the button is enabled" do
-      browser.button(:name, 'new_user_submit').should be_enabled
+      expect(browser.button(:name, 'new_user_submit')).to be_enabled
     end
 
     it "returns false if the button is disabled" do
-      browser.button(:name, 'new_user_submit_disabled').should_not be_enabled
+      expect(browser.button(:name, 'new_user_submit_disabled')).to_not be_enabled
     end
 
     it "raises UnknownObjectException if the button doesn't exist" do
-      lambda { browser.button(:name, "no_such_name").enabled? }.should raise_error(UnknownObjectException)
+      expect{ browser.button(:name, "no_such_name").enabled? }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#disabled?" do
     it "returns false when button is enabled" do
-      browser.button(:name, 'new_user_submit').should_not be_disabled
+      expect(browser.button(:name, 'new_user_submit')).to_not be_disabled
     end
 
     it "returns true when button is disabled" do
-      browser.button(:name, 'new_user_submit_disabled').should be_disabled
+      expect(browser.button(:name, 'new_user_submit_disabled')).to be_disabled
     end
 
     it "raises UnknownObjectException if button does not exist" do
-      lambda { browser.button(:name, "no_such_name").disabled? }.should raise_error(UnknownObjectException)
+      expect{ browser.button(:name, "no_such_name").disabled? }.to raise_error(UnknownObjectException)
     end
   end
 
@@ -263,21 +263,21 @@ describe "Button" do
     it "clicks the button if it exists" do
       browser.goto(WatirSpec.url_for("forms_with_input_elements.html", :needs_server => true))
       browser.button(:id, 'delete_user_submit').click
-      browser.text.should include("Semantic table")
+      expect(browser.text).to include("Semantic table")
     end
 
     it "fires events" do
       browser.button(:id, 'new_user_button').click
-      browser.button(:id, 'new_user_button').value.should == 'new_value_set_by_onclick_event'
+      expect(browser.button(:id, 'new_user_button').value).to eq 'new_value_set_by_onclick_event'
     end
 
     it "raises UnknownObjectException when clicking a button that doesn't exist" do
-      lambda { browser.button(:value, "no_such_value").click }.should raise_error(UnknownObjectException)
-      lambda { browser.button(:id, "no_such_id").click }.should raise_error(UnknownObjectException)
+      expect{ browser.button(:value, "no_such_value").click }.to raise_error(UnknownObjectException)
+      expect{ browser.button(:id, "no_such_id").click }.to raise_error(UnknownObjectException)
     end
 
     it "raises ObjectDisabledException when clicking a disabled button" do
-      lambda { browser.button(:value, "Disabled").click }.should raise_error(ObjectDisabledException)
+      expect{ browser.button(:value, "Disabled").click }.to raise_error(ObjectDisabledException)
     end
   end
 

--- a/buttons_spec.rb
+++ b/buttons_spec.rb
@@ -10,32 +10,32 @@ describe "Buttons" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.buttons(:name => "new_user_button").to_a.should == [browser.button(:name => "new_user_button")]
+        expect(browser.buttons(:name => "new_user_button").to_a).to eq [browser.button(:name => "new_user_button")]
       end
     end
   end
 
   describe "#length" do
     it "returns the number of buttons" do
-      browser.buttons.length.should == 9
+      expect(browser.buttons.length).to eq 9
     end
   end
 
   describe "#[]" do
     it "returns the button at the given index" do
-      browser.buttons[0].title.should == "Submit the form"
+      expect(browser.buttons[0].title).to eq "Submit the form"
     end
   end
 
   describe "#first" do
     it "returns the first element in the collection" do
-      browser.buttons.first.value.should == browser.buttons[0].value
+      expect(browser.buttons.first.value).to eq browser.buttons[0].value
     end
   end
 
   describe "#last" do
     it "returns the last element in the collection" do
-      browser.buttons.last.value.should == browser.buttons[-1].value
+      expect(browser.buttons.last.value).to eq browser.buttons[-1].value
     end
   end
 
@@ -44,14 +44,14 @@ describe "Buttons" do
       count = 0
 
       browser.buttons.each_with_index do |b, index|
-        b.name.should == browser.button(:index, index).name
-        b.id.should == browser.button(:index, index).id
-        b.value.should == browser.button(:index, index).value
+        expect(b.name).to eq browser.button(:index, index).name
+        expect(b.id).to eq browser.button(:index, index).id
+        expect(b.value).to eq browser.button(:index, index).value
 
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/checkbox_spec.rb
+++ b/checkbox_spec.rb
@@ -11,67 +11,67 @@ describe "CheckBox" do
 
   describe "#exists?" do
     it "returns true if the checkbox button exists" do
-      browser.checkbox(:id, "new_user_interests_books").should exist
-      browser.checkbox(:id, /new_user_interests_books/).should exist
-      browser.checkbox(:name, "new_user_interests").should exist
-      browser.checkbox(:name, /new_user_interests/).should exist
-      browser.checkbox(:value, "books").should exist
-      browser.checkbox(:value, /books/).should exist
+      expect(browser.checkbox(:id, "new_user_interests_books")).to exist
+      expect(browser.checkbox(:id, /new_user_interests_books/)).to exist
+      expect(browser.checkbox(:name, "new_user_interests")).to exist
+      expect(browser.checkbox(:name, /new_user_interests/)).to exist
+      expect(browser.checkbox(:value, "books")).to exist
+      expect(browser.checkbox(:value, /books/)).to exist
       # not sure what :text is supposed to represent here
-      # browser.checkbox(:text, "books").should exist
-      # browser.checkbox(:text, /books/).should exist
-      browser.checkbox(:class, "fun").should exist
-      browser.checkbox(:class, /fun/).should exist
-      browser.checkbox(:index, 0).should exist
-      browser.checkbox(:xpath, "//input[@id='new_user_interests_books']").should exist
+      # browser.checkbox(:text, "books").to exist
+      # browser.checkbox(:text, /books/).to exist
+      expect(browser.checkbox(:class, "fun")).to exist
+      expect(browser.checkbox(:class, /fun/)).to exist
+      expect(browser.checkbox(:index, 0)).to exist
+      expect(browser.checkbox(:xpath, "//input[@id='new_user_interests_books']")).to exist
     end
 
     it "returns true if the checkbox button exists (search by name and value)" do
-      browser.checkbox(:name => "new_user_interests", :value => 'cars').should exist
+      expect(browser.checkbox(:name => "new_user_interests", :value => 'cars')).to exist
       browser.checkbox(:xpath, "//input[@name='new_user_interests' and @value='cars']").set
     end
 
     it "returns the first checkbox if given no args" do
-      browser.checkbox.should exist
+      expect(browser.checkbox).to exist
     end
 
     it "returns false if the checkbox button does not exist" do
-      browser.checkbox(:id, "no_such_id").should_not exist
-      browser.checkbox(:id, /no_such_id/).should_not exist
-      browser.checkbox(:name, "no_such_name").should_not exist
-      browser.checkbox(:name, /no_such_name/).should_not exist
-      browser.checkbox(:value, "no_such_value").should_not exist
-      browser.checkbox(:value, /no_such_value/).should_not exist
-      browser.checkbox(:text, "no_such_text").should_not exist
-      browser.checkbox(:text, /no_such_text/).should_not exist
-      browser.checkbox(:class, "no_such_class").should_not exist
-      browser.checkbox(:class, /no_such_class/).should_not exist
-      browser.checkbox(:index, 1337).should_not exist
-      browser.checkbox(:xpath, "//input[@id='no_such_id']").should_not exist
+      expect(browser.checkbox(:id, "no_such_id")).to_not exist
+      expect(browser.checkbox(:id, /no_such_id/)).to_not exist
+      expect(browser.checkbox(:name, "no_such_name")).to_not exist
+      expect(browser.checkbox(:name, /no_such_name/)).to_not exist
+      expect(browser.checkbox(:value, "no_such_value")).to_not exist
+      expect(browser.checkbox(:value, /no_such_value/)).to_not exist
+      expect(browser.checkbox(:text, "no_such_text")).to_not exist
+      expect(browser.checkbox(:text, /no_such_text/)).to_not exist
+      expect(browser.checkbox(:class, "no_such_class")).to_not exist
+      expect(browser.checkbox(:class, /no_such_class/)).to_not exist
+      expect(browser.checkbox(:index, 1337)).to_not exist
+      expect(browser.checkbox(:xpath, "//input[@id='no_such_id']")).to_not exist
     end
 
     it "returns false if the checkbox button does not exist (search by name and value)" do
-      browser.checkbox(:name => "new_user_interests", :value => 'no_such_value').should_not exist
-      browser.checkbox(:xpath, "//input[@name='new_user_interests' and @value='no_such_value']").should_not exist
-      browser.checkbox(:name => "no_such_name", :value => 'cars').should_not exist
-      browser.checkbox(:xpath, "//input[@name='no_such_name' and @value='cars']").should_not exist
+      expect(browser.checkbox(:name => "new_user_interests", :value => 'no_such_value')).to_not exist
+      expect(browser.checkbox(:xpath, "//input[@name='new_user_interests' and @value='no_such_value']")).to_not exist
+      expect(browser.checkbox(:name => "no_such_name", :value => 'cars')).to_not exist
+      expect(browser.checkbox(:xpath, "//input[@name='no_such_name' and @value='cars']")).to_not exist
     end
 
     it "returns true for checkboxes with a string value" do
-      browser.checkbox(:name => 'new_user_interests', :value => 'books').should exist
-      browser.checkbox(:name => 'new_user_interests', :value => 'cars').should exist
+      expect(browser.checkbox(:name => 'new_user_interests', :value => 'books')).to exist
+      expect(browser.checkbox(:name => 'new_user_interests', :value => 'cars')).to exist
     end
 
     it "returns true for checkbox with upper case type" do
-      browser.checkbox(:id, "new_user_interests_draw").should exist
+      expect(browser.checkbox(:id, "new_user_interests_draw")).to exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.checkbox(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.checkbox(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.checkbox(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.checkbox(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
@@ -79,88 +79,88 @@ describe "CheckBox" do
 
   describe "#class_name" do
     it "returns the class name if the checkbox exists and has an attribute" do
-      browser.checkbox(:id, "new_user_interests_dancing").class_name.should == "fun"
+      expect(browser.checkbox(:id, "new_user_interests_dancing").class_name).to eq "fun"
     end
 
     it "returns an empty string if the checkbox exists and the attribute doesn't" do
-      browser.checkbox(:id, "new_user_interests_books").class_name.should == ""
+      expect(browser.checkbox(:id, "new_user_interests_books").class_name).to eq ""
     end
 
     it "raises UnknownObjectException if the checkbox doesn't exist" do
-      lambda { browser.checkbox(:id, "no_such_id").class_name }.should raise_error(UnknownObjectException)
+      expect{ browser.checkbox(:id, "no_such_id").class_name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#id" do
     it "returns the id attribute if the checkbox exists and has an attribute" do
-      browser.checkbox(:index, 0).id.should == "new_user_interests_books"
+      expect(browser.checkbox(:index, 0).id).to eq "new_user_interests_books"
     end
 
     it "returns an empty string if the checkbox exists and the attribute doesn't" do
-      browser.checkbox(:index, 1).id.should == ""
+      expect(browser.checkbox(:index, 1).id).to eq ""
     end
 
     it "raises UnknownObjectException if the checkbox doesn't exist" do
-      lambda { browser.checkbox(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{ browser.checkbox(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#name" do
     it "returns the name attribute if the checkbox exists" do
-      browser.checkbox(:id, 'new_user_interests_books').name.should == "new_user_interests"
+      expect(browser.checkbox(:id, 'new_user_interests_books').name).to eq "new_user_interests"
     end
 
     it "returns an empty string if the checkbox exists and the attribute doesn't" do
-      browser.checkbox(:id, 'new_user_interests_food').name.should == ""
+      expect(browser.checkbox(:id, 'new_user_interests_food').name).to eq ""
     end
 
     it "raises UnknownObjectException if the checkbox doesn't exist" do
-      lambda { browser.checkbox(:index, 1337).name }.should raise_error(UnknownObjectException)
+      expect{ browser.checkbox(:index, 1337).name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#title" do
     it "returns the title attribute if the checkbox exists" do
-      browser.checkbox(:id, "new_user_interests_dancing").title.should == "Dancing is fun!"
+      expect(browser.checkbox(:id, "new_user_interests_dancing").title).to eq "Dancing is fun!"
     end
 
     it "returns an empty string if the checkbox exists and the attribute doesn't" do
-      browser.checkbox(:id, "new_user_interests_books").title.should == ""
+      expect(browser.checkbox(:id, "new_user_interests_books").title).to eq ""
     end
 
     it "raises UnknownObjectException if the checkbox doesn't exist" do
-      lambda { browser.checkbox(:index, 1337).title }.should raise_error(UnknownObjectException)
+      expect{ browser.checkbox(:index, 1337).title }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#type" do
     it "returns the type attribute if the checkbox exists" do
-      browser.checkbox(:index, 0).type.should == "checkbox"
+      expect(browser.checkbox(:index, 0).type).to eq "checkbox"
     end
 
     it "raises UnknownObjectException if the checkbox doesn't exist" do
-      lambda { browser.checkbox(:index, 1337).type }.should raise_error(UnknownObjectException)
+      expect{ browser.checkbox(:index, 1337).type }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#value" do
     it "returns the value attribute if the checkbox exists" do
-      browser.checkbox(:id, 'new_user_interests_books').value.should == 'books'
+      expect(browser.checkbox(:id, 'new_user_interests_books').value).to eq 'books'
     end
 
     it "raises UnknownObjectException if the checkbox doesn't exist" do
-      lambda { browser.checkbox(:index, 1337).value}.should raise_error(UnknownObjectException)
+      expect{ browser.checkbox(:index, 1337).value}.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.checkbox(:index, 0).should respond_to(:class_name)
-      browser.checkbox(:index, 0).should respond_to(:id)
-      browser.checkbox(:index, 0).should respond_to(:name)
-      browser.checkbox(:index, 0).should respond_to(:title)
-      browser.checkbox(:index, 0).should respond_to(:type)
-      browser.checkbox(:index, 0).should respond_to(:value)
+      expect(browser.checkbox(:index, 0)).to respond_to(:class_name)
+      expect(browser.checkbox(:index, 0)).to respond_to(:id)
+      expect(browser.checkbox(:index, 0)).to respond_to(:name)
+      expect(browser.checkbox(:index, 0)).to respond_to(:title)
+      expect(browser.checkbox(:index, 0)).to respond_to(:type)
+      expect(browser.checkbox(:index, 0)).to respond_to(:value)
     end
   end
 
@@ -168,32 +168,32 @@ describe "CheckBox" do
 
   describe "#enabled?" do
     it "returns true if the checkbox button is enabled" do
-      browser.checkbox(:id, "new_user_interests_books").should be_enabled
-      browser.checkbox(:xpath, "//input[@id='new_user_interests_books']").should be_enabled
+      expect(browser.checkbox(:id, "new_user_interests_books")).to be_enabled
+      expect(browser.checkbox(:xpath, "//input[@id='new_user_interests_books']")).to be_enabled
     end
 
     it "returns false if the checkbox button is disabled" do
-      browser.checkbox(:id, "new_user_interests_dentistry").should_not be_enabled
-      browser.checkbox(:xpath,"//input[@id='new_user_interests_dentistry']").should_not be_enabled
+      expect(browser.checkbox(:id, "new_user_interests_dentistry")).to_not be_enabled
+      expect(browser.checkbox(:xpath,"//input[@id='new_user_interests_dentistry']")).to_not be_enabled
     end
 
     it "raises UnknownObjectException if the checkbox button doesn't exist" do
-      lambda { browser.checkbox(:id, "no_such_id").enabled?  }.should raise_error(UnknownObjectException)
-      lambda { browser.checkbox(:xpath, "//input[@id='no_such_id']").enabled?  }.should raise_error(UnknownObjectException)
+      expect{ browser.checkbox(:id, "no_such_id").enabled?  }.to raise_error(UnknownObjectException)
+      expect{ browser.checkbox(:xpath, "//input[@id='no_such_id']").enabled?  }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#disabled?" do
     it "returns true if the checkbox is disabled" do
-      browser.checkbox(:id, 'new_user_interests_dentistry').should be_disabled
+      expect(browser.checkbox(:id, 'new_user_interests_dentistry')).to be_disabled
     end
 
     it "returns false if the checkbox is enabled" do
-      browser.checkbox(:id, 'new_user_interests_books').should_not be_disabled
+      expect(browser.checkbox(:id, 'new_user_interests_books')).to_not be_disabled
     end
 
     it "raises UnknownObjectException if the checkbox doesn't exist" do
-      lambda { browser.checkbox(:index, 1337).disabled? }.should raise_error(UnknownObjectException)
+      expect{ browser.checkbox(:index, 1337).disabled? }.to raise_error(UnknownObjectException)
     end
   end
 
@@ -201,54 +201,54 @@ describe "CheckBox" do
 
   describe "#clear" do
     it "raises ObjectDisabledException if the checkbox is disabled" do
-      browser.checkbox(:id, "new_user_interests_dentistry").should_not be_set
-      lambda { browser.checkbox(:id, "new_user_interests_dentistry").clear }.should raise_error(ObjectDisabledException)
-      lambda { browser.checkbox(:xpath, "//input[@id='new_user_interests_dentistry']").clear }.should raise_error(ObjectDisabledException)
+      expect(browser.checkbox(:id, "new_user_interests_dentistry")).to_not be_set
+      expect{ browser.checkbox(:id, "new_user_interests_dentistry").clear }.to raise_error(ObjectDisabledException)
+      expect{ browser.checkbox(:xpath, "//input[@id='new_user_interests_dentistry']").clear }.to raise_error(ObjectDisabledException)
     end
 
     it "clears the checkbox button if it is set" do
       browser.checkbox(:id, "new_user_interests_books").clear
-      browser.checkbox(:id, "new_user_interests_books").should_not be_set
+      expect(browser.checkbox(:id, "new_user_interests_books")).to_not be_set
     end
 
     it "clears the checkbox button when found by :xpath" do
       browser.checkbox(:xpath, "//input[@id='new_user_interests_books']").clear
-      browser.checkbox(:xpath, "//input[@id='new_user_interests_books']").should_not be_set
+      expect(browser.checkbox(:xpath, "//input[@id='new_user_interests_books']")).to_not be_set
     end
 
     it "raises UnknownObjectException if the checkbox button doesn't exist" do
-      lambda { browser.checkbox(:name, "no_such_id").clear }.should raise_error(UnknownObjectException)
-      lambda { browser.checkbox(:xpath, "//input[@id='no_such_id']").clear  }.should raise_error(UnknownObjectException)
+      expect{ browser.checkbox(:name, "no_such_id").clear }.to raise_error(UnknownObjectException)
+      expect{ browser.checkbox(:xpath, "//input[@id='no_such_id']").clear  }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#set" do
     it "sets the checkbox button" do
       browser.checkbox(:id, "new_user_interests_cars").set
-      browser.checkbox(:id, "new_user_interests_cars").should be_set
+      expect(browser.checkbox(:id, "new_user_interests_cars")).to be_set
     end
 
     it "sets the checkbox button when found by :xpath" do
       browser.checkbox(:xpath, "//input[@id='new_user_interests_cars']").set
-      browser.checkbox(:xpath, "//input[@id='new_user_interests_cars']").should be_set
+      expect(browser.checkbox(:xpath, "//input[@id='new_user_interests_cars']")).to be_set
     end
 
     it "fires the onclick event" do
-      browser.button(:id, "disabled_button").should be_disabled
+      expect(browser.button(:id, "disabled_button")).to be_disabled
       browser.checkbox(:id, "toggle_button_checkbox").set
-      browser.button(:id, "disabled_button").should_not be_disabled
+      expect(browser.button(:id, "disabled_button")).to_not be_disabled
       browser.checkbox(:id, "toggle_button_checkbox").clear
-      browser.button(:id, "disabled_button").should be_disabled
+      expect(browser.button(:id, "disabled_button")).to be_disabled
     end
 
     it "raises UnknownObjectException if the checkbox button doesn't exist" do
-      lambda { browser.checkbox(:name, "no_such_name").set  }.should raise_error(UnknownObjectException)
-      lambda { browser.checkbox(:xpath, "//input[@name='no_such_name']").set  }.should raise_error(UnknownObjectException)
+      expect{ browser.checkbox(:name, "no_such_name").set  }.to raise_error(UnknownObjectException)
+      expect{ browser.checkbox(:xpath, "//input[@name='no_such_name']").set  }.to raise_error(UnknownObjectException)
     end
 
     it "raises ObjectDisabledException if the checkbox is disabled" do
-      lambda { browser.checkbox(:id, "new_user_interests_dentistry").set  }.should raise_error(ObjectDisabledException)
-      lambda { browser.checkbox(:xpath, "//input[@id='new_user_interests_dentistry']").set  }.should raise_error(ObjectDisabledException )
+      expect{ browser.checkbox(:id, "new_user_interests_dentistry").set  }.to raise_error(ObjectDisabledException)
+      expect{ browser.checkbox(:xpath, "//input[@id='new_user_interests_dentistry']").set  }.to raise_error(ObjectDisabledException )
     end
   end
 
@@ -256,24 +256,24 @@ describe "CheckBox" do
 
   describe '#set?' do
     it "returns true if the checkbox button is set" do
-      browser.checkbox(:id, "new_user_interests_books").should be_set
+      expect(browser.checkbox(:id, "new_user_interests_books")).to be_set
     end
 
     it "returns false if the checkbox button unset" do
-      browser.checkbox(:id, "new_user_interests_cars").should_not be_set
+      expect(browser.checkbox(:id, "new_user_interests_cars")).to_not be_set
     end
 
     it "returns the state for checkboxes with string values" do
-      browser.checkbox(:name => "new_user_interests", :value => 'cars').should_not be_set
+      expect(browser.checkbox(:name => "new_user_interests", :value => 'cars')).to_not be_set
       browser.checkbox(:name => "new_user_interests", :value => 'cars').set
-      browser.checkbox(:name => "new_user_interests", :value => 'cars').should be_set
+      expect(browser.checkbox(:name => "new_user_interests", :value => 'cars')).to be_set
       browser.checkbox(:name => "new_user_interests", :value => 'cars').clear
-      browser.checkbox(:name => "new_user_interests", :value => 'cars').should_not be_set
+      expect(browser.checkbox(:name => "new_user_interests", :value => 'cars')).to_not be_set
     end
 
     it "raises UnknownObjectException if the checkbox button doesn't exist" do
-      lambda { browser.checkbox(:id, "no_such_id").set?  }.should raise_error(UnknownObjectException)
-      lambda { browser.checkbox(:xpath, "//input[@id='no_such_id']").set?  }.should raise_error(UnknownObjectException)
+      expect{ browser.checkbox(:id, "no_such_id").set?  }.to raise_error(UnknownObjectException)
+      expect{ browser.checkbox(:xpath, "//input[@id='no_such_id']").set?  }.to raise_error(UnknownObjectException)
     end
   end
 

--- a/checkboxes_spec.rb
+++ b/checkboxes_spec.rb
@@ -10,20 +10,20 @@ describe "CheckBoxes" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.checkboxes(:value => "books").to_a.should == [browser.checkbox(:value => "books")]
+        expect(browser.checkboxes(:value => "books").to_a).to eq [browser.checkbox(:value => "books")]
       end
     end
   end
 
   describe "#length" do
     it "returns the number of checkboxes" do
-      browser.checkboxes.length.should == 8
+      expect(browser.checkboxes.length).to eq 8
     end
   end
 
   describe "#[]" do
     it "returns the checkbox at the given index" do
-      browser.checkboxes[0].id.should == "new_user_interests_books"
+      expect(browser.checkboxes[0].id).to eq "new_user_interests_books"
     end
   end
 
@@ -32,15 +32,15 @@ describe "CheckBoxes" do
       count = 0
 
       browser.checkboxes.each_with_index do |c, index|
-        c.should be_instance_of(CheckBox)
-        c.name.should == browser.checkbox(:index, index).name
-        c.id.should == browser.checkbox(:index, index).id
-        c.value.should == browser.checkbox(:index, index).value
+        expect(c).to be_instance_of(CheckBox)
+        expect(c.name).to eq browser.checkbox(:index, index).name
+        expect(c.id).to eq browser.checkbox(:index, index).id
+        expect(c.value).to eq browser.checkbox(:index, index).value
 
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/collections_spec.rb
+++ b/collections_spec.rb
@@ -8,10 +8,10 @@ describe "Collections" do
   end
 
   it "returns inner elements of parent element having different html tag" do
-    browser.span(:id => "a_span").divs.size.should == 2
+    expect(browser.span(:id => "a_span").divs.size).to eq 2
   end
 
   it "returns inner elements of parent element having same html tag" do
-    browser.span(:id => "a_span").spans.size.should == 2
+    expect(browser.span(:id => "a_span").spans.size).to eq 2
   end
 end

--- a/cookies_spec.rb
+++ b/cookies_spec.rb
@@ -5,7 +5,7 @@ describe "Browser#cookies" do
 
   it 'gets an empty list of cookies' do
     browser.goto WatirSpec.url_for 'collections.html' # no cookie set.
-    browser.cookies.to_a.should == []
+    expect(browser.cookies.to_a).to eq []
   end
 
   it "gets any cookies set" do
@@ -14,8 +14,8 @@ describe "Browser#cookies" do
     verify_cookies_count 1
 
     cookie = browser.cookies.to_a.first
-    cookie[:name].should == 'monster'
-    cookie[:value].should == '1'
+    expect(cookie[:name]).to eq 'monster'
+    expect(cookie[:value]).to eq '1'
   end
 
   not_compliant_on [:webdriver, :internet_explorer] do
@@ -44,19 +44,19 @@ describe "Browser#cookies" do
 
       browser.cookies.add 'a', 'b', options
       cookie = browser.cookies.to_a.find { |e| e[:name] == 'a' }
-      cookie.should_not be_nil
+      expect(cookie).to_not be_nil
 
-      cookie[:name].should == 'a'
-      cookie[:value].should == 'b'
+      expect(cookie[:name]).to eq 'a'
+      expect(cookie[:value]).to eq 'b'
 
       not_compliant_on :watir_classic do
-        cookie[:path].should == "/set_cookie"
-        cookie[:secure].should be_true
+        expect(cookie[:path]).to eq "/set_cookie"
+        expect(cookie[:secure]).to be_true
 
-        cookie[:expires].should be_kind_of(Time)
+        expect(cookie[:expires]).to be_kind_of(Time)
 
         # a few ms slack
-        cookie[:expires].to_i.should be_within(2).of(expires.to_i)
+        expect((cookie[:expires]).to_i).to be_within(2).of(expires.to_i)
       end
     end
   end
@@ -87,6 +87,6 @@ describe "Browser#cookies" do
 
   def verify_cookies_count expected_size
     cookies = browser.cookies.to_a
-    cookies.size.should eq(expected_size), "expected #{expected_size} cookies, got #{cookies.size}: #{cookies.inspect}"
+    expect(cookies.size).to eq(expected_size), "expected #{expected_size} cookies, got #{cookies.size}: #{cookies.inspect}"
   end
 end

--- a/dd_spec.rb
+++ b/dd_spec.rb
@@ -10,117 +10,117 @@ describe "Dd" do
   # Exists method
   describe "#exists?" do
     it "returns true if the element exists" do
-      browser.dd(:id, "someone").should exist
-      browser.dd(:class, "name").should exist
-      browser.dd(:xpath, "//dd[@id='someone']").should exist
-      browser.dd(:index, 0).should exist
+      expect(browser.dd(:id, "someone")).to exist
+      expect(browser.dd(:class, "name")).to exist
+      expect(browser.dd(:xpath, "//dd[@id='someone']")).to exist
+      expect(browser.dd(:index, 0)).to exist
     end
 
     it "returns the first dd if given no args" do
-      browser.dd.should exist
+      expect(browser.dd).to exist
     end
 
     it "returns false if the element does not exist" do
-      browser.dd(:id, "no_such_id").should_not exist
+      expect(browser.dd(:id, "no_such_id")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.dd(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.dd(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.dd(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.dd(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Attribute methods
   describe "#class_name" do
     it "returns the class attribute if the element exists" do
-      browser.dd(:id, "someone").class_name.should == "name"
+      expect(browser.dd(:id, "someone").class_name).to eq "name"
     end
 
     it "returns an empty string if the element exists but the attribute doesn't" do
-      browser.dd(:id, "city").class_name.should == ""
+      expect(browser.dd(:id, "city").class_name).to eq ""
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      lambda { browser.dd(:id, "no_such_id").class_name }.should raise_error(UnknownObjectException)
-      lambda { browser.dd(:title, "no_such_title").class_name }.should raise_error(UnknownObjectException)
-      lambda { browser.dd(:index, 1337).class_name }.should raise_error(UnknownObjectException)
-      lambda { browser.dd(:xpath, "//dd[@id='no_such_id']").class_name }.should raise_error(UnknownObjectException)
+      expect{ browser.dd(:id, "no_such_id").class_name }.to raise_error(UnknownObjectException)
+      expect{ browser.dd(:title, "no_such_title").class_name }.to raise_error(UnknownObjectException)
+      expect{ browser.dd(:index, 1337).class_name }.to raise_error(UnknownObjectException)
+      expect{ browser.dd(:xpath, "//dd[@id='no_such_id']").class_name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#id" do
     it "returns the id attribute if the element exists" do
-      browser.dd(:class, 'name').id.should == "someone"
+      expect(browser.dd(:class, 'name').id).to eq "someone"
     end
 
     it "returns an empty string if the element exists, but the attribute doesn't" do
-      browser.dd(:class, 'address').id.should == ""
+      expect(browser.dd(:class, 'address').id).to eq ""
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      lambda {browser.dd(:id, "no_such_id").id }.should raise_error(UnknownObjectException)
-      lambda {browser.dd(:title, "no_such_id").id }.should raise_error(UnknownObjectException)
-      lambda {browser.dd(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{browser.dd(:id, "no_such_id").id }.to raise_error(UnknownObjectException)
+      expect{browser.dd(:title, "no_such_id").id }.to raise_error(UnknownObjectException)
+      expect{browser.dd(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#title" do
     it "returns the title of the element" do
-      browser.dd(:class, "name").title.should == "someone"
+      expect(browser.dd(:class, "name").title).to eq "someone"
     end
   end
 
   describe "#text" do
     it "returns the text of the element" do
-      browser.dd(:id, "someone").text.should == "John Doe"
+      expect(browser.dd(:id, "someone").text).to eq "John Doe"
     end
 
     it "returns an empty string if the element exists but contains no text" do
-      browser.dd(:class, 'noop').text.should == ""
+      expect(browser.dd(:class, 'noop').text).to eq ""
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      lambda { browser.dd(:id, "no_such_id").text }.should raise_error(UnknownObjectException)
-      lambda { browser.dd(:title, "no_such_title").text }.should raise_error(UnknownObjectException)
-      lambda { browser.dd(:index, 1337).text }.should raise_error(UnknownObjectException)
-      lambda { browser.dd(:xpath, "//dd[@id='no_such_id']").text }.should raise_error(UnknownObjectException)
+      expect{ browser.dd(:id, "no_such_id").text }.to raise_error(UnknownObjectException)
+      expect{ browser.dd(:title, "no_such_title").text }.to raise_error(UnknownObjectException)
+      expect{ browser.dd(:index, 1337).text }.to raise_error(UnknownObjectException)
+      expect{ browser.dd(:xpath, "//dd[@id='no_such_id']").text }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.dd(:index, 0).should respond_to(:id)
-      browser.dd(:index, 0).should respond_to(:class_name)
-      browser.dd(:index, 0).should respond_to(:style)
-      browser.dd(:index, 0).should respond_to(:text)
-      browser.dd(:index, 0).should respond_to(:title)
+      expect(browser.dd(:index, 0)).to respond_to(:id)
+      expect(browser.dd(:index, 0)).to respond_to(:class_name)
+      expect(browser.dd(:index, 0)).to respond_to(:style)
+      expect(browser.dd(:index, 0)).to respond_to(:text)
+      expect(browser.dd(:index, 0)).to respond_to(:title)
     end
   end
 
   # Manipulation methods
   describe "#click" do
     it "fires events when clicked" do
-      browser.dd(:title, 'education').text.should_not == 'changed'
+      expect(browser.dd(:title, 'education').text).to_not eq 'changed'
       browser.dd(:title, 'education').click
-      browser.dd(:title, 'education').text.should == 'changed'
+      expect(browser.dd(:title, 'education').text).to eq 'changed'
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      lambda { browser.dd(:id, "no_such_id").click }.should raise_error(UnknownObjectException)
-      lambda { browser.dd(:title, "no_such_title").click }.should raise_error(UnknownObjectException)
-      lambda { browser.dd(:index, 1337).click }.should raise_error(UnknownObjectException)
-      lambda { browser.dd(:xpath, "//dd[@id='no_such_id']").click }.should raise_error(UnknownObjectException)
+      expect{ browser.dd(:id, "no_such_id").click }.to raise_error(UnknownObjectException)
+      expect{ browser.dd(:title, "no_such_title").click }.to raise_error(UnknownObjectException)
+      expect{ browser.dd(:index, 1337).click }.to raise_error(UnknownObjectException)
+      expect{ browser.dd(:xpath, "//dd[@id='no_such_id']").click }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#html" do
     it "returns the HTML of the element" do
       html = browser.dd(:id, 'someone').html
-      html.should =~ /John Doe/m
-      html.should_not include('</body>')
+      expect(html).to match(/John Doe/m)
+      expect(html).to_not include('</body>')
     end
   end
 

--- a/dds_spec.rb
+++ b/dds_spec.rb
@@ -10,20 +10,20 @@ describe "Dds" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.dds(:text => "11 years").to_a.should == [browser.dd(:text => "11 years")]
+        expect(browser.dds(:text => "11 years").to_a).to eq [browser.dd(:text => "11 years")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the number of dds" do
-      browser.dds.length.should == 11
+      expect(browser.dds.length).to eq 11
     end
   end
 
   describe "#[]" do
     it "returns the dd at the given index" do
-      browser.dds[1].title.should == "education"
+      expect(browser.dds[1].title).to eq "education"
     end
   end
 
@@ -32,13 +32,13 @@ describe "Dds" do
       count = 0
 
       browser.dds.each_with_index do |d, index|
-        d.id.should == browser.dd(:index, index).id
-        d.class_name.should == browser.dd(:index, index).class_name
+        expect(d.id).to eq browser.dd(:index, index).id
+        expect(d.class_name).to eq browser.dd(:index, index).class_name
 
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/del_spec.rb
+++ b/del_spec.rb
@@ -10,120 +10,120 @@ describe "Del" do
   # Exists method
   describe "#exist?" do
     it "returns true if the 'del' exists" do
-      browser.del(:id, "lead").should exist
-      browser.del(:id, /lead/).should exist
-      browser.del(:text, "This is a deleted text tag 1").should exist
-      browser.del(:text, /This is a deleted text tag 1/).should exist
-      browser.del(:class, "lead").should exist
-      browser.del(:class, /lead/).should exist
-      browser.del(:index, 0).should exist
-      browser.del(:xpath, "//del[@id='lead']").should exist
+      expect(browser.del(:id, "lead")).to exist
+      expect(browser.del(:id, /lead/)).to exist
+      expect(browser.del(:text, "This is a deleted text tag 1")).to exist
+      expect(browser.del(:text, /This is a deleted text tag 1/)).to exist
+      expect(browser.del(:class, "lead")).to exist
+      expect(browser.del(:class, /lead/)).to exist
+      expect(browser.del(:index, 0)).to exist
+      expect(browser.del(:xpath, "//del[@id='lead']")).to exist
     end
 
     it "returns the first del if given no args" do
-      browser.del.should exist
+      expect(browser.del).to exist
     end
 
     it "returns false if the element doesn't exist" do
-      browser.del(:id, "no_such_id").should_not exist
-      browser.del(:id, /no_such_id/).should_not exist
-      browser.del(:text, "no_such_text").should_not exist
-      browser.del(:text, /no_such_text/).should_not exist
-      browser.del(:class, "no_such_class").should_not exist
-      browser.del(:class, /no_such_class/).should_not exist
-      browser.del(:index, 1337).should_not exist
-      browser.del(:xpath, "//del[@id='no_such_id']").should_not exist
+      expect(browser.del(:id, "no_such_id")).to_not exist
+      expect(browser.del(:id, /no_such_id/)).to_not exist
+      expect(browser.del(:text, "no_such_text")).to_not exist
+      expect(browser.del(:text, /no_such_text/)).to_not exist
+      expect(browser.del(:class, "no_such_class")).to_not exist
+      expect(browser.del(:class, /no_such_class/)).to_not exist
+      expect(browser.del(:index, 1337)).to_not exist
+      expect(browser.del(:xpath, "//del[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.del(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.del(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.del(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.del(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Attribute methods
   describe "#class_name" do
     it "returns the class attribute" do
-      browser.del(:index, 0).class_name.should == 'lead'
+      expect(browser.del(:index, 0).class_name).to eq 'lead'
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.del(:index, 2).class_name.should == ''
+      expect(browser.del(:index, 2).class_name).to eq ''
     end
 
     it "raises UnknownObjectException if the del doesn't exist" do
-      lambda { browser.del(:id, 'no_such_id').class_name }.should raise_error(UnknownObjectException)
+      expect{ browser.del(:id, 'no_such_id').class_name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#id" do
     it "returns the id attribute" do
-      browser.del(:index, 0).id.should == "lead"
+      expect(browser.del(:index, 0).id).to eq "lead"
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.del(:index, 2).id.should == ''
+      expect(browser.del(:index, 2).id).to eq ''
     end
 
     it "raises UnknownObjectException if the del doesn't exist" do
-      lambda { browser.del(:id, "no_such_id").id }.should raise_error(UnknownObjectException)
-      lambda { browser.del(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{ browser.del(:id, "no_such_id").id }.to raise_error(UnknownObjectException)
+      expect{ browser.del(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#title" do
     it "returns the title attribute" do
-      browser.del(:index, 0).title.should == 'Lorem ipsum'
+      expect(browser.del(:index, 0).title).to eq 'Lorem ipsum'
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.del(:index, 2).title.should == ''
+      expect(browser.del(:index, 2).title).to eq ''
     end
 
     it "raises UnknownObjectException if the del doesn't exist" do
-      lambda { browser.del(:id, 'no_such_id').title }.should raise_error( UnknownObjectException)
-      lambda { browser.del(:xpath, "//del[@id='no_such_id']").title }.should raise_error( UnknownObjectException)
+      expect{ browser.del(:id, 'no_such_id').title }.to raise_error( UnknownObjectException)
+      expect{ browser.del(:xpath, "//del[@id='no_such_id']").title }.to raise_error( UnknownObjectException)
     end
   end
 
   describe "#text" do
     it "returns the text of the del" do
-      browser.del(:index, 1).text.should == 'This is a deleted text tag 2'
+      expect(browser.del(:index, 1).text).to eq 'This is a deleted text tag 2'
     end
 
     it "returns an empty string if the element doesn't contain any text" do
-      browser.del(:index, 3).text.should == ''
+      expect(browser.del(:index, 3).text).to eq ''
     end
 
     it "raises UnknownObjectException if the del doesn't exist" do
-      lambda { browser.del(:id, 'no_such_id').text }.should raise_error( UnknownObjectException)
-      lambda { browser.del(:xpath , "//del[@id='no_such_id']").text }.should raise_error( UnknownObjectException)
+      expect{ browser.del(:id, 'no_such_id').text }.to raise_error( UnknownObjectException)
+      expect{ browser.del(:xpath , "//del[@id='no_such_id']").text }.to raise_error( UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.del(:index, 0).should respond_to(:class_name)
-      browser.del(:index, 0).should respond_to(:id)
-      browser.del(:index, 0).should respond_to(:title)
-      browser.del(:index, 0).should respond_to(:text)
+      expect(browser.del(:index, 0)).to respond_to(:class_name)
+      expect(browser.del(:index, 0)).to respond_to(:id)
+      expect(browser.del(:index, 0)).to respond_to(:title)
+      expect(browser.del(:index, 0)).to respond_to(:text)
     end
   end
 
   # Other
   describe "#click" do
     it "fires events" do
-      browser.del(:class, 'footer').text.should_not include('Javascript')
+      expect(browser.del(:class, 'footer').text).to_not include('Javascript')
       browser.del(:class, 'footer').click
-      browser.del(:class, 'footer').text.should include('Javascript')
+      expect(browser.del(:class, 'footer').text).to include('Javascript')
     end
 
     it "raises UnknownObjectException if the del doesn't exist" do
-      lambda { browser.del(:id, "no_such_id").click }.should raise_error(UnknownObjectException)
-      lambda { browser.del(:title, "no_such_title").click }.should raise_error(UnknownObjectException)
+      expect{ browser.del(:id, "no_such_id").click }.to raise_error(UnknownObjectException)
+      expect{ browser.del(:title, "no_such_title").click }.to raise_error(UnknownObjectException)
     end
   end
 end

--- a/dels_spec.rb
+++ b/dels_spec.rb
@@ -10,20 +10,20 @@ describe "Dels" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.dels(:class => "lead").to_a.should == [browser.del(:class => "lead")]
+        expect(browser.dels(:class => "lead").to_a).to eq [browser.del(:class => "lead")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the number of dels" do
-      browser.dels.length.should == 5
+      expect(browser.dels.length).to eq 5
     end
   end
 
   describe "#[]" do
     it "returns the del at the given index" do
-      browser.dels[0].id.should == "lead"
+      expect(browser.dels[0].id).to eq "lead"
     end
   end
 
@@ -32,11 +32,11 @@ describe "Dels" do
       count = 0
 
       browser.dels.each_with_index do |s, index|
-        s.id.should == browser.del(:index, index).id
+        expect(s.id).to eq browser.del(:index, index).id
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/div_spec.rb
+++ b/div_spec.rb
@@ -10,41 +10,41 @@ describe "Div" do
   # Exists method
   describe "#exists?" do
     it "returns true if the element exists" do
-      browser.div(:id, "header").should exist
-      browser.div(:id, /header/).should exist
-      browser.div(:title, "Header and primary navigation").should exist
-      browser.div(:title, /Header and primary navigation/).should exist
-      browser.div(:text, "This is a footer.").should exist
-      browser.div(:text, /This is a footer\./).should exist
-      browser.div(:class, "profile").should exist
-      browser.div(:class, /profile/).should exist
-      browser.div(:index, 0).should exist
-      browser.div(:xpath, "//div[@id='header']").should exist
+      expect(browser.div(:id, "header")).to exist
+      expect(browser.div(:id, /header/)).to exist
+      expect(browser.div(:title, "Header and primary navigation")).to exist
+      expect(browser.div(:title, /Header and primary navigation/)).to exist
+      expect(browser.div(:text, "This is a footer.")).to exist
+      expect(browser.div(:text, /This is a footer\./)).to exist
+      expect(browser.div(:class, "profile")).to exist
+      expect(browser.div(:class, /profile/)).to exist
+      expect(browser.div(:index, 0)).to exist
+      expect(browser.div(:xpath, "//div[@id='header']")).to exist
     end
 
     it "returns the first div if given no args" do
-      browser.div.should exist
+      expect(browser.div).to exist
     end
 
     it "returns false if the element does not exist" do
-      browser.div(:id, "no_such_id").should_not exist
-      browser.div(:id, /no_such_id/).should_not exist
-      browser.div(:title, "no_such_title").should_not exist
-      browser.div(:title, /no_such_title/).should_not exist
-      browser.div(:text, "no_such_text").should_not exist
-      browser.div(:text, /no_such_text/).should_not exist
-      browser.div(:class, "no_such_class").should_not exist
-      browser.div(:class, /no_such_class/).should_not exist
-      browser.div(:index, 1337).should_not exist
-      browser.div(:xpath, "//div[@id='no_such_id']").should_not exist
+      expect(browser.div(:id, "no_such_id")).to_not exist
+      expect(browser.div(:id, /no_such_id/)).to_not exist
+      expect(browser.div(:title, "no_such_title")).to_not exist
+      expect(browser.div(:title, /no_such_title/)).to_not exist
+      expect(browser.div(:text, "no_such_text")).to_not exist
+      expect(browser.div(:text, /no_such_text/)).to_not exist
+      expect(browser.div(:class, "no_such_class")).to_not exist
+      expect(browser.div(:class, /no_such_class/)).to_not exist
+      expect(browser.div(:index, 1337)).to_not exist
+      expect(browser.div(:xpath, "//div[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.div(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.div(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.div(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.div(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
 
   end
@@ -52,114 +52,114 @@ describe "Div" do
   # Attribute methods
   describe "#class_name" do
     it "returns the class attribute if the element exists" do
-      browser.div(:id, "footer").class_name.should == "profile"
+      expect(browser.div(:id, "footer").class_name).to eq "profile"
     end
 
     it "returns an empty string if the element exists but the attribute doesn't" do
-      browser.div(:id, "content").class_name.should == ""
+      expect(browser.div(:id, "content").class_name).to eq ""
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      lambda { browser.div(:id, "no_such_id").class_name }.should raise_error(UnknownObjectException)
-      lambda { browser.div(:title, "no_such_title").class_name }.should raise_error(UnknownObjectException)
-      lambda { browser.div(:index, 1337).class_name }.should raise_error(UnknownObjectException)
-      lambda { browser.div(:xpath, "//div[@id='no_such_id']").class_name }.should raise_error(UnknownObjectException)
+      expect{ browser.div(:id, "no_such_id").class_name }.to raise_error(UnknownObjectException)
+      expect{ browser.div(:title, "no_such_title").class_name }.to raise_error(UnknownObjectException)
+      expect{ browser.div(:index, 1337).class_name }.to raise_error(UnknownObjectException)
+      expect{ browser.div(:xpath, "//div[@id='no_such_id']").class_name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#id" do
     it "returns the id attribute if the element exists" do
-      browser.div(:index, 1).id.should == "outer_container"
+      expect(browser.div(:index, 1).id).to eq "outer_container"
     end
 
     it "returns an empty string if the element exists, but the attribute doesn't" do
-      browser.div(:index, 0).id.should == ""
+      expect(browser.div(:index, 0).id).to eq ""
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      lambda { browser.div(:id, "no_such_id").id }.should raise_error(UnknownObjectException)
-      lambda { browser.div(:title, "no_such_id").id }.should raise_error(UnknownObjectException)
-      lambda { browser.div(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{ browser.div(:id, "no_such_id").id }.to raise_error(UnknownObjectException)
+      expect{ browser.div(:title, "no_such_id").id }.to raise_error(UnknownObjectException)
+      expect{ browser.div(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
 
     it "should take all conditions into account when locating by id" do
       browser.goto WatirSpec.url_for "multiple_ids.html"
-      browser.div(:id => "multiple", :class => "bar").class_name.should == "bar"
+      expect(browser.div(:id => "multiple", :class => "bar").class_name).to eq "bar"
     end
   end
 
   describe "#style" do
     not_compliant_on :internet_explorer do
       it "returns the style attribute if the element exists" do
-        browser.div(:id, 'best_language').style.should == "color: red; text-decoration: underline; cursor: pointer;"
+        expect(browser.div(:id, 'best_language').style).to eq "color: red; text-decoration: underline; cursor: pointer;"
       end
     end
 
     deviates_on :internet_explorer8 do
       it "returns the style attribute if the element exists" do
-        browser.div(:id, 'best_language').style.should == "COLOR: red; CURSOR: pointer; TEXT-DECORATION: underline"
+        expect(browser.div(:id, 'best_language').style).to eq "COLOR: red; CURSOR: pointer; TEXT-DECORATION: underline"
       end
     end
     deviates_on :internet_explorer9 do
       it "returns the style attribute if the element exists" do
-        browser.div(:id, 'best_language').style.should == "color: red; text-decoration: underline; cursor: pointer;"
+        expect(browser.div(:id, 'best_language').style).to eq "color: red; text-decoration: underline; cursor: pointer;"
       end
     end
 
     it "returns an empty string if the element exists but the attribute doesn't" do
-      browser.div(:id, 'promo').style.should == ""
+      expect(browser.div(:id, 'promo').style).to eq ""
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      lambda {browser.div(:id, "no_such_id").style }.should raise_error(UnknownObjectException)
+      expect{browser.div(:id, "no_such_id").style }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#text" do
     it "returns the text of the div" do
-      browser.div(:id, "footer").text.strip.should == "This is a footer."
-      browser.div(:title, "Closing remarks").text.strip.should == "This is a footer."
-      browser.div(:xpath, "//div[@id='footer']").text.strip.should == "This is a footer."
+      expect(browser.div(:id, "footer").text.strip).to eq "This is a footer."
+      expect(browser.div(:title, "Closing remarks").text.strip).to eq "This is a footer."
+      expect(browser.div(:xpath, "//div[@id='footer']").text.strip).to eq "This is a footer."
     end
 
     it "returns an empty string if the element exists but contains no text" do
-      browser.div(:index, 0).text.strip.should == ""
+      expect(browser.div(:index, 0).text.strip).to eq ""
     end
 
     it "returns an empty string if the div is hidden" do
-      browser.div(:id, 'hidden').text.should == ""
+      expect(browser.div(:id, 'hidden').text).to eq ""
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      lambda { browser.div(:id, "no_such_id").text }.should raise_error(UnknownObjectException)
-      lambda { browser.div(:title, "no_such_title").text }.should raise_error(UnknownObjectException)
-      lambda { browser.div(:index, 1337).text }.should raise_error(UnknownObjectException)
-      lambda { browser.div(:xpath, "//div[@id='no_such_id']").text }.should raise_error(UnknownObjectException)
+      expect{ browser.div(:id, "no_such_id").text }.to raise_error(UnknownObjectException)
+      expect{ browser.div(:title, "no_such_title").text }.to raise_error(UnknownObjectException)
+      expect{ browser.div(:index, 1337).text }.to raise_error(UnknownObjectException)
+      expect{ browser.div(:xpath, "//div[@id='no_such_id']").text }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.div(:index, 0).should respond_to(:class_name)
-      browser.div(:index, 0).should respond_to(:id)
-      browser.div(:index, 0).should respond_to(:style)
-      browser.div(:index, 0).should respond_to(:text)
+      expect(browser.div(:index, 0)).to respond_to(:class_name)
+      expect(browser.div(:index, 0)).to respond_to(:id)
+      expect(browser.div(:index, 0)).to respond_to(:style)
+      expect(browser.div(:index, 0)).to respond_to(:text)
     end
   end
 
   # Manipulation methods
   describe "#click" do
     it "fires events when clicked" do
-      browser.div(:id, 'best_language').text.should_not == 'Ruby!'
+      expect(browser.div(:id, 'best_language').text).to_not eq 'Ruby!'
       browser.div(:id, 'best_language').click
-      browser.div(:id, 'best_language').text.should == 'Ruby!'
+      expect(browser.div(:id, 'best_language').text).to eq 'Ruby!'
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      lambda { browser.div(:id, "no_such_id").click }.should raise_error(UnknownObjectException)
-      lambda { browser.div(:title, "no_such_title").click }.should raise_error(UnknownObjectException)
-      lambda { browser.div(:index, 1337).click }.should raise_error(UnknownObjectException)
-      lambda { browser.div(:xpath, "//div[@id='no_such_id']").click }.should raise_error(UnknownObjectException)
+      expect{ browser.div(:id, "no_such_id").click }.to raise_error(UnknownObjectException)
+      expect{ browser.div(:title, "no_such_title").click }.to raise_error(UnknownObjectException)
+      expect{ browser.div(:index, 1337).click }.to raise_error(UnknownObjectException)
+      expect{ browser.div(:xpath, "//div[@id='no_such_id']").click }.to raise_error(UnknownObjectException)
     end
   end
 
@@ -167,7 +167,7 @@ describe "Div" do
     describe "#double_click" do
       it "fires the ondblclick event" do
         browser.div(:id, 'html_test').double_click
-        messages.should include('double clicked')
+        expect(messages).to include('double clicked')
       end
     end
 
@@ -176,7 +176,7 @@ describe "Div" do
         browser.goto(WatirSpec.url_for("right_click.html"))
         browser.div(:id, "click").right_click
         bug "https://github.com/detro/ghostdriver/issues/125", :phantomjs do
-          messages.first.should == 'right-clicked'
+          expect(messages.first).to eq 'right-clicked'
         end
       end
     end
@@ -186,29 +186,29 @@ describe "Div" do
     not_compliant_on :internet_explorer do
       it "returns the HTML of the element" do
         html = browser.div(:id, 'footer').html.downcase
-        html.should include('id="footer"')
-        html.should include('title="closing remarks"')
-        html.should include('class="profile"')
+        expect(html).to include('id="footer"')
+        expect(html).to include('title="closing remarks"')
+        expect(html).to include('class="profile"')
 
-        html.should_not include('<div id="content">')
-        html.should_not include('</body>')
+        expect(html).to_not include('<div id="content">')
+        expect(html).to_not include('</body>')
       end
     end
 
     deviates_on :internet_explorer do
       it "returns the HTML of the element" do
         html = browser.div(:id, 'footer').html.downcase
-        html.should include('title="closing remarks"')
-        html.should_not include('</body>')
+        expect(html).to include('title="closing remarks"')
+        expect(html).to_not include('</body>')
         deviates_on :internet_explorer8 do
-          html.should include('id=footer')
-          html.should include('class=profile')
-          html.should_not include('<div id=content>')
+          expect(html).to include('id=footer')
+          expect(html).to include('class=profile')
+          expect(html).to_not include('<div id=content>')
         end
         deviates_on :internet_explorer9 do
-          html.should include('id="footer"')
-          html.should include('class="profile"')
-          html.should_not include('<div id="content">')
+          expect(html).to include('id="footer"')
+          expect(html).to include('class="profile"')
+          expect(html).to_not include('<div id="content">')
         end
       end
     end

--- a/divs_spec.rb
+++ b/divs_spec.rb
@@ -10,20 +10,20 @@ describe "Divs" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.divs(:id => "header").to_a.should == [browser.div(:id => "header")]
+        expect(browser.divs(:id => "header").to_a).to eq [browser.div(:id => "header")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the number of divs" do
-      browser.divs.length.should == 12
+      expect(browser.divs.length).to eq 12
     end
   end
 
   describe "#[]" do
     it "returns the div at the given index" do
-      browser.divs[1].id.should == "outer_container"
+      expect(browser.divs[1].id).to eq "outer_container"
     end
   end
 
@@ -32,13 +32,13 @@ describe "Divs" do
       count = 0
 
       browser.divs.each_with_index do |d, index|
-        d.id.should == browser.div(:index, index).id
-        d.class_name.should == browser.div(:index, index).class_name
+        expect(d.id).to eq browser.div(:index, index).id
+        expect(d.class_name).to eq browser.div(:index, index).class_name
 
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/dl_spec.rb
+++ b/dl_spec.rb
@@ -10,109 +10,109 @@ describe "Dl" do
   # Exists method
   describe "#exists?" do
     it "returns true if the element exists" do
-      browser.dl(:id, "experience-list").should exist
-      browser.dl(:class, "list").should exist
-      browser.dl(:xpath, "//dl[@id='experience-list']").should exist
-      browser.dl(:index, 0).should exist
+      expect(browser.dl(:id, "experience-list")).to exist
+      expect(browser.dl(:class, "list")).to exist
+      expect(browser.dl(:xpath, "//dl[@id='experience-list']")).to exist
+      expect(browser.dl(:index, 0)).to exist
     end
 
     it "returns the first dl if given no args" do
-      browser.dl.should exist
+      expect(browser.dl).to exist
     end
 
     it "returns false if the element does not exist" do
-      browser.dl(:id, "no_such_id").should_not exist
+      expect(browser.dl(:id, "no_such_id")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.dl(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.dl(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.dl(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.dl(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Attribute methods
   describe "#class_name" do
     it "returns the class attribute if the element exists" do
-      browser.dl(:id, "experience-list").class_name.should == "list"
+      expect(browser.dl(:id, "experience-list").class_name).to eq "list"
     end
 
     it "returns an empty string if the element exists but the attribute doesn't" do
-      browser.dl(:id, "noop").class_name.should == ""
+      expect(browser.dl(:id, "noop").class_name).to eq ""
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      lambda { browser.dl(:id, "no_such_id").class_name }.should raise_error(UnknownObjectException)
-      lambda { browser.dl(:title, "no_such_title").class_name }.should raise_error(UnknownObjectException)
-      lambda { browser.dl(:index, 1337).class_name }.should raise_error(UnknownObjectException)
-      lambda { browser.dl(:xpath, "//dl[@id='no_such_id']").class_name }.should raise_error(UnknownObjectException)
+      expect{ browser.dl(:id, "no_such_id").class_name }.to raise_error(UnknownObjectException)
+      expect{ browser.dl(:title, "no_such_title").class_name }.to raise_error(UnknownObjectException)
+      expect{ browser.dl(:index, 1337).class_name }.to raise_error(UnknownObjectException)
+      expect{ browser.dl(:xpath, "//dl[@id='no_such_id']").class_name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#id" do
     it "returns the id attribute if the element exists" do
-      browser.dl(:class, 'list').id.should == "experience-list"
+      expect(browser.dl(:class, 'list').id).to eq "experience-list"
     end
 
     it "returns an empty string if the element exists, but the attribute doesn't" do
-      browser.dl(:class, 'personalia').id.should == ""
+      expect(browser.dl(:class, 'personalia').id).to eq ""
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      lambda {browser.dl(:id, "no_such_id").id }.should raise_error(UnknownObjectException)
-      lambda {browser.dl(:title, "no_such_id").id }.should raise_error(UnknownObjectException)
-      lambda {browser.dl(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{browser.dl(:id, "no_such_id").id }.to raise_error(UnknownObjectException)
+      expect{browser.dl(:title, "no_such_id").id }.to raise_error(UnknownObjectException)
+      expect{browser.dl(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#title" do
     it "returns the id attribute if the element exists" do
-      browser.dl(:class, 'list').title.should == "experience"
+      expect(browser.dl(:class, 'list').title).to eq "experience"
     end
   end
 
   describe "#text" do
     it "returns the text of the element" do
-      browser.dl(:id, "experience-list").text.should include("11 years")
+      expect(browser.dl(:id, "experience-list").text).to include("11 years")
     end
 
     it "returns an empty string if the element exists but contains no text" do
-      browser.dl(:id, 'noop').text.should == ""
+      expect(browser.dl(:id, 'noop').text).to eq ""
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      lambda { browser.dl(:id, "no_such_id").text }.should raise_error(UnknownObjectException)
-      lambda { browser.dl(:title, "no_such_title").text }.should raise_error(UnknownObjectException)
-      lambda { browser.dl(:index, 1337).text }.should raise_error(UnknownObjectException)
-      lambda { browser.dl(:xpath, "//dl[@id='no_such_id']").text }.should raise_error(UnknownObjectException)
+      expect{ browser.dl(:id, "no_such_id").text }.to raise_error(UnknownObjectException)
+      expect{ browser.dl(:title, "no_such_title").text }.to raise_error(UnknownObjectException)
+      expect{ browser.dl(:index, 1337).text }.to raise_error(UnknownObjectException)
+      expect{ browser.dl(:xpath, "//dl[@id='no_such_id']").text }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.dl(:index, 0).should respond_to(:id)
-      browser.dl(:index, 0).should respond_to(:class_name)
-      browser.dl(:index, 0).should respond_to(:style)
-      browser.dl(:index, 0).should respond_to(:text)
-      browser.dl(:index, 0).should respond_to(:title)
+      expect(browser.dl(:index, 0)).to respond_to(:id)
+      expect(browser.dl(:index, 0)).to respond_to(:class_name)
+      expect(browser.dl(:index, 0)).to respond_to(:style)
+      expect(browser.dl(:index, 0)).to respond_to(:text)
+      expect(browser.dl(:index, 0)).to respond_to(:title)
     end
   end
 
   # Manipulation methods
   describe "#click" do
     it "fires events when clicked" do
-      browser.dt(:id, 'name').text.should_not == 'changed!'
+      expect(browser.dt(:id, 'name').text).to_not eq 'changed!'
       browser.dt(:id, 'name').click
-      browser.dt(:id, 'name').text.should == 'changed!'
+      expect(browser.dt(:id, 'name').text).to eq 'changed!'
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      lambda { browser.dl(:id, "no_such_id").click }.should raise_error(UnknownObjectException)
-      lambda { browser.dl(:title, "no_such_title").click }.should raise_error(UnknownObjectException)
-      lambda { browser.dl(:index, 1337).click }.should raise_error(UnknownObjectException)
-      lambda { browser.dl(:xpath, "//dl[@id='no_such_id']").click }.should raise_error(UnknownObjectException)
+      expect{ browser.dl(:id, "no_such_id").click }.to raise_error(UnknownObjectException)
+      expect{ browser.dl(:title, "no_such_title").click }.to raise_error(UnknownObjectException)
+      expect{ browser.dl(:index, 1337).click }.to raise_error(UnknownObjectException)
+      expect{ browser.dl(:xpath, "//dl[@id='no_such_id']").click }.to raise_error(UnknownObjectException)
     end
   end
 
@@ -120,31 +120,31 @@ describe "Dl" do
     it "returns the HTML of the element" do
       html = browser.dl(:id, 'experience-list').html.downcase
       not_compliant_on :internet_explorer do
-        html.should include('<dt class="current-industry">')
+        expect(html).to include('<dt class="current-industry">')
       end
 
       deviates_on :internet_explorer9, :internet_explorer10 do
-        html.should include('<dt class="current-industry">')
+        expect(html).to include('<dt class="current-industry">')
       end
 
       not_compliant_on :internet_explorer9, :internet_explorer10 do
         deviates_on :internet_explorer do
-          html.should include('<dt class=current-industry>')
+          expect(html).to include('<dt class=current-industry>')
         end
       end
 
-      html.should_not include('</body>')
+      expect(html).to_not include('</body>')
     end
   end
 
   describe "#to_hash" do
     it "converts the dl to a Hash" do
-      browser.dl(:id, 'experience-list').to_hash.should == {
+      expect(browser.dl(:id, 'experience-list').to_hash).to eq Hash[
         "Experience"                   => "11 years",
         "Education"                    => "Master",
         "Current industry"             => "Architecture",
         "Previous industry experience" => "Architecture"
-      }
+      ]
     end
   end
 

--- a/dls_spec.rb
+++ b/dls_spec.rb
@@ -10,20 +10,20 @@ describe "Dls" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.dls(:title => "experience").to_a.should == [browser.dl(:title => "experience")]
+        expect(browser.dls(:title => "experience").to_a).to eq [browser.dl(:title => "experience")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the number of dls" do
-      browser.dls.length.should == 3
+      expect(browser.dls.length).to eq 3
     end
   end
 
   describe "#[]" do
     it "returns the dl at the given index" do
-      browser.dls[0].id.should == "experience-list"
+      expect(browser.dls[0].id).to eq "experience-list"
     end
   end
 
@@ -32,14 +32,14 @@ describe "Dls" do
       count = 0
 
       browser.dls.each_with_index do |d, index|
-        d.text.should == browser.dl(:index, index).text
-        d.id.should == browser.dl(:index, index).id
-        d.class_name.should == browser.dl(:index, index).class_name
+        expect(d.text).to eq browser.dl(:index, index).text
+        expect(d.id).to eq browser.dl(:index, index).id
+        expect(d.class_name).to eq browser.dl(:index, index).class_name
 
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/drag_and_drop_spec.rb
+++ b/drag_and_drop_spec.rb
@@ -9,11 +9,11 @@ describe "Element" do
 
     not_compliant_on [:webdriver, :iphone] do
       it "can drag and drop an element onto another" do
-        droppable.text.should == 'Drop here'
+        expect(droppable.text).to eq 'Drop here'
         draggable.drag_and_drop_on droppable
-        droppable.text.should == 'Dropped!'
+        expect(droppable.text).to eq 'Dropped!'
       end
-      
+
       bug "http://code.google.com/p/selenium/issues/detail?id=3075", [:webdriver, :firefox] do
         it "can drag and drop an element onto another when draggable is out of viewport" do
           reposition "draggable"
@@ -27,9 +27,9 @@ describe "Element" do
       end
 
       it "can drag an element by the given offset" do
-        droppable.text.should == 'Drop here'
+        expect(droppable.text).to eq 'Drop here'
         draggable.drag_and_drop_by 200, 50
-        droppable.text.should == 'Dropped!'
+        expect(droppable.text).to eq 'Dropped!'
       end
 
       def reposition(what)
@@ -37,9 +37,9 @@ describe "Element" do
       end
 
       def perform_drag_and_drop_on_droppable
-        droppable.text.should == "Drop here"
+        expect(droppable.text).to eq "Drop here"
         draggable.drag_and_drop_on droppable
-        droppable.text.should == 'Dropped!'
+        expect(droppable.text).to eq 'Dropped!'
       end
     end
 

--- a/dt_spec.rb
+++ b/dt_spec.rb
@@ -10,117 +10,117 @@ describe "Dt" do
   # Exists method
   describe "#exists?" do
     it "returns true if the element exists" do
-      browser.dt(:id, "experience").should exist
-      browser.dt(:class, "current-industry").should exist
-      browser.dt(:xpath, "//dt[@id='experience']").should exist
-      browser.dt(:index, 0).should exist
+      expect(browser.dt(:id, "experience")).to exist
+      expect(browser.dt(:class, "current-industry")).to exist
+      expect(browser.dt(:xpath, "//dt[@id='experience']")).to exist
+      expect(browser.dt(:index, 0)).to exist
     end
 
     it "returns the first dt if given no args" do
-      browser.dt.should exist
+      expect(browser.dt).to exist
     end
 
     it "returns false if the element does not exist" do
-      browser.dt(:id, "no_such_id").should_not exist
+      expect(browser.dt(:id, "no_such_id")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.dt(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.dt(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.dt(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.dt(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Attribute methods
   describe "#class_name" do
     it "returns the class attribute if the element exists" do
-      browser.dt(:id , "experience").class_name.should == "industry"
+      expect(browser.dt(:id , "experience").class_name).to eq "industry"
     end
 
     it "returns an empty string if the element exists but the attribute doesn't" do
-      browser.dt(:id , "education").class_name.should == ""
+      expect(browser.dt(:id , "education").class_name).to eq ""
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      lambda { browser.dt(:id, "no_such_id").class_name }.should raise_error(UnknownObjectException)
-      lambda { browser.dt(:title, "no_such_title").class_name }.should raise_error(UnknownObjectException)
-      lambda { browser.dt(:index, 1337).class_name }.should raise_error(UnknownObjectException)
-      lambda { browser.dt(:xpath, "//dt[@id='no_such_id']").class_name }.should raise_error(UnknownObjectException)
+      expect{ browser.dt(:id, "no_such_id").class_name }.to raise_error(UnknownObjectException)
+      expect{ browser.dt(:title, "no_such_title").class_name }.to raise_error(UnknownObjectException)
+      expect{ browser.dt(:index, 1337).class_name }.to raise_error(UnknownObjectException)
+      expect{ browser.dt(:xpath, "//dt[@id='no_such_id']").class_name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#id" do
     it "returns the id attribute if the element exists" do
-      browser.dt(:class, 'industry').id.should == "experience"
+      expect(browser.dt(:class, 'industry').id).to eq "experience"
     end
 
     it "returns an empty string if the element exists, but the attribute doesn't" do
-      browser.dt(:class, 'current-industry').id.should == ""
+      expect(browser.dt(:class, 'current-industry').id).to eq ""
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      lambda {browser.dt(:id, "no_such_id").id }.should raise_error(UnknownObjectException)
-      lambda {browser.dt(:title, "no_such_id").id }.should raise_error(UnknownObjectException)
-      lambda {browser.dt(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{browser.dt(:id, "no_such_id").id }.to raise_error(UnknownObjectException)
+      expect{browser.dt(:title, "no_such_id").id }.to raise_error(UnknownObjectException)
+      expect{browser.dt(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#title" do
     it "returns the title of the element" do
-      browser.dt(:id, "experience").title.should == "experience"
+      expect(browser.dt(:id, "experience").title).to eq "experience"
     end
   end
 
   describe "#text" do
     it "returns the text of the element" do
-      browser.dt(:id, "experience").text.should == "Experience"
+      expect(browser.dt(:id, "experience").text).to eq "Experience"
     end
 
     it "returns an empty string if the element exists but contains no text" do
-      browser.dt(:class, 'noop').text.should == ""
+      expect(browser.dt(:class, 'noop').text).to eq ""
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      lambda { browser.dt(:id, "no_such_id").text }.should raise_error(UnknownObjectException)
-      lambda { browser.dt(:title, "no_such_title").text }.should raise_error(UnknownObjectException)
-      lambda { browser.dt(:index, 1337).text }.should raise_error(UnknownObjectException)
-      lambda { browser.dt(:xpath, "//dt[@id='no_such_id']").text }.should raise_error(UnknownObjectException)
+      expect{ browser.dt(:id, "no_such_id").text }.to raise_error(UnknownObjectException)
+      expect{ browser.dt(:title, "no_such_title").text }.to raise_error(UnknownObjectException)
+      expect{ browser.dt(:index, 1337).text }.to raise_error(UnknownObjectException)
+      expect{ browser.dt(:xpath, "//dt[@id='no_such_id']").text }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.dt(:index, 0).should respond_to(:id)
-      browser.dt(:index, 0).should respond_to(:class_name)
-      browser.dt(:index, 0).should respond_to(:style)
-      browser.dt(:index, 0).should respond_to(:text)
-      browser.dt(:index, 0).should respond_to(:title)
+      expect(browser.dt(:index, 0)).to respond_to(:id)
+      expect(browser.dt(:index, 0)).to respond_to(:class_name)
+      expect(browser.dt(:index, 0)).to respond_to(:style)
+      expect(browser.dt(:index, 0)).to respond_to(:text)
+      expect(browser.dt(:index, 0)).to respond_to(:title)
     end
   end
 
   # Manipulation methods
   describe "#click" do
     it "fires events when clicked" do
-      browser.dt(:id, 'education').text.should_not == 'changed'
+      expect(browser.dt(:id, 'education').text).to_not eq 'changed'
       browser.dt(:id, 'education').click
-      browser.dt(:id, 'education').text.should == 'changed'
+      expect(browser.dt(:id, 'education').text).to eq 'changed'
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      lambda { browser.dt(:id, "no_such_id").click }.should raise_error(UnknownObjectException)
-      lambda { browser.dt(:title, "no_such_title").click }.should raise_error(UnknownObjectException)
-      lambda { browser.dt(:index, 1337).click }.should raise_error(UnknownObjectException)
-      lambda { browser.dt(:xpath, "//dt[@id='no_such_id']").click }.should raise_error(UnknownObjectException)
+      expect{ browser.dt(:id, "no_such_id").click }.to raise_error(UnknownObjectException)
+      expect{ browser.dt(:title, "no_such_title").click }.to raise_error(UnknownObjectException)
+      expect{ browser.dt(:index, 1337).click }.to raise_error(UnknownObjectException)
+      expect{ browser.dt(:xpath, "//dt[@id='no_such_id']").click }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#html" do
     it "returns the HTML of the element" do
       html = browser.dt(:id, 'name').html
-      html.should =~ %r[<div>.*Name.*</div>]mi
-      html.should_not include('</body>')
+      expect(html).to match(%r[<div>.*Name.*</div>]mi)
+      expect(html).to_not include('</body>')
     end
   end
 

--- a/dts_spec.rb
+++ b/dts_spec.rb
@@ -10,20 +10,20 @@ describe "Dts" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.dts(:class => "current-industry").to_a.should == [browser.dt(:class => "current-industry")]
+        expect(browser.dts(:class => "current-industry").to_a).to eq [browser.dt(:class => "current-industry")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the number of dts" do
-      browser.dts.length.should == 11
+      expect(browser.dts.length).to eq 11
     end
   end
 
   describe "#[]" do
     it "returns the dt at the given index" do
-      browser.dts[0].id.should == "experience"
+      expect(browser.dts[0].id).to eq "experience"
     end
   end
 
@@ -32,13 +32,13 @@ describe "Dts" do
       count = 0
 
       browser.dts.each_with_index do |d, index|
-        d.id.should == browser.dt(:index, index).id
-        d.class_name.should == browser.dt(:index, index).class_name
+        expect(d.id).to eq browser.dt(:index, index).id
+        expect(d.class_name).to eq browser.dt(:index, index).class_name
 
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/element_spec.rb
+++ b/element_spec.rb
@@ -9,42 +9,42 @@ describe "Element" do
 
   describe ".new" do
     it "finds elements matching the conditions when given a hash of :how => 'what' arguments" do
-      browser.checkbox(:name => 'new_user_interests', :title => 'Dancing is fun!').value.should == 'dancing'
-      browser.text_field(:class_name => 'name', :index => 1).id.should == 'new_user_last_name'
+      expect(browser.checkbox(:name => 'new_user_interests', :title => 'Dancing is fun!').value).to eq 'dancing'
+      expect(browser.text_field(:class_name => 'name', :index => 1).id).to eq 'new_user_last_name'
     end
 
     it "raises UnknownObjectException with a sane error message when given a hash of :how => 'what' arguments (non-existing object)" do
-      lambda { browser.text_field(:index => 100, :name => "foo").id }.should raise_error(UnknownObjectException)
+      expect{ browser.text_field(:index => 100, :name => "foo").id }.to raise_error(UnknownObjectException)
     end
 
     it "raises ArgumentError if given the wrong number of arguments" do
       container = double("container").as_null_object
-      lambda { Element.new(container, 1,2,3,4) }.should raise_error(ArgumentError)
-      lambda { Element.new(container, "foo") }.should raise_error(ArgumentError)
+      expect{ Element.new(container, 1,2,3,4) }.to raise_error(ArgumentError)
+      expect{ Element.new(container, "foo") }.to raise_error(ArgumentError)
     end
   end
 
-  describe "#== and #eql?" do
+  describe "#eq and #eql?" do
     before { browser.goto WatirSpec.url_for("definition_lists.html") }
 
     it "returns true if the two elements point to the same DOM element" do
       a = browser.dl(:id => "experience-list")
       b = browser.dl
 
-      a.should == b
-      a.should eql(b)
+      expect(a).to eq b
+      expect(a).to eql(b)
     end
 
     it "returns false if the two elements are not the same" do
       a = browser.dls[0]
       b = browser.dls[1]
 
-      a.should_not == b
-      a.should_not eql(b)
+      expect(a).to_not eq b
+      expect(a).to_not eql(b)
     end
 
     it "returns false if the other object is not an Element" do
-      browser.dl.should_not == 1
+      expect(browser.dl).to_not eq 1
     end
   end
 
@@ -53,65 +53,65 @@ describe "Element" do
 
     bug "http://github.com/jarib/celerity/issues#issue/27", :celerity do
       it "finds elements by a data-* attribute" do
-        browser.p(:data_type => "ruby-library").should exist
+        expect(browser.p(:data_type => "ruby-library")).to exist
       end
 
       it "returns the value of a data-* attribute" do
-        browser.p.data_type.should == "ruby-library"
+        expect(browser.p.data_type).to eq "ruby-library"
       end
     end
   end
 
   describe "finding with unknown tag name" do
     it "finds an element by xpath" do
-      browser.element(:xpath => "//*[@for='new_user_first_name']").should exist
+      expect(browser.element(:xpath => "//*[@for='new_user_first_name']")).to exist
     end
 
     it "finds an element by arbitrary attribute" do
-      browser.element(:title => "no title").should exist
+      expect(browser.element(:title => "no title")).to exist
     end
 
     it "raises MissingWayOfFindingObjectException if the attribute is invalid for the element type" do
-      lambda {
+      expect{
         browser.element(:for => "no title").exists?
-      }.should raise_error(MissingWayOfFindingObjectException)
+      }.to raise_error(MissingWayOfFindingObjectException)
 
-      lambda {
+      expect{
         browser.element(:name => "new_user_first_name").exists?
-      }.should raise_error(MissingWayOfFindingObjectException)
+      }.to raise_error(MissingWayOfFindingObjectException)
 
-      lambda {
+      expect{
         browser.element(:value => //).exists?
-      }.should raise_error(MissingWayOfFindingObjectException)
+      }.to raise_error(MissingWayOfFindingObjectException)
     end
 
     it "finds several elements by xpath" do
-      browser.elements(:xpath => "//a").length.should == 1
+      expect(browser.elements(:xpath => "//a").length).to eq 1
     end
 
     it "finds finds several elements by arbitrary attribute" do
-      browser.elements(:id => /^new_user/).length.should == 32
+      expect(browser.elements(:id => /^new_user/).length).to eq 32
     end
 
     it "finds an element from an element's subtree" do
-      browser.fieldset.element(:id => "first_label").should exist
-      browser.field_set.element(:id => "first_label").should exist
+      expect(browser.fieldset.element(:id => "first_label")).to exist
+      expect(browser.field_set.element(:id => "first_label")).to exist
     end
 
     it "finds several elements from an element's subtree" do
-      browser.fieldset.elements(:xpath => ".//label").length.should == 14
+      expect(browser.fieldset.elements(:xpath => ".//label").length).to eq 14
     end
   end
 
   describe "#to_subtype" do
     it "returns a more precise subtype of Element (input element)" do
       el = browser.element(:xpath => "//input[@type='radio']").to_subtype
-      el.should be_kind_of(Watir::Radio)
+      expect(el).to be_kind_of(Watir::Radio)
     end
 
     it "returns a more precise subtype of Element" do
       el = browser.element(:xpath => "//*[@id='messages']").to_subtype
-      el.should be_kind_of(Watir::Div)
+      expect(el).to be_kind_of(Watir::Div)
     end
   end
 
@@ -119,63 +119,63 @@ describe "Element" do
     bug "http://code.google.com/p/selenium/issues/detail?id=157", [:webdriver, :firefox] do
       it "fires the onfocus event for the given element" do
         tf = browser.text_field(:id, "new_user_occupation")
-        tf.value.should == "Developer"
+        expect(tf.value).to eq "Developer"
         tf.focus
-        browser.div(:id, "onfocus_test").text.should == "changed by onfocus event"
+        expect(browser.div(:id, "onfocus_test").text).to eq "changed by onfocus event"
       end
     end
   end
 
   describe "#focused?" do
     it "knows if the element is focused" do
-      browser.element(:id => 'new_user_first_name').should be_focused
-      browser.element(:id => 'new_user_last_name').should_not be_focused
+      expect(browser.element(:id => 'new_user_first_name')).to be_focused
+      expect(browser.element(:id => 'new_user_last_name')).to_not be_focused
     end
   end
 
   describe "#fire_event" do
     it "should fire the given event" do
-      browser.div(:id, "onfocus_test").text.should be_empty
+      expect(browser.div(:id, "onfocus_test").text).to be_empty
       browser.text_field(:id, "new_user_occupation").fire_event('onfocus')
-      browser.div(:id, "onfocus_test").text.should == "changed by onfocus event"
+      expect(browser.div(:id, "onfocus_test").text).to eq "changed by onfocus event"
     end
   end
 
   describe "#parent" do
     bug "http://github.com/jarib/celerity/issues#issue/28", :celerity do
       it "gets the parent of this element" do
-        browser.text_field(:id, "new_user_email").parent.should be_instance_of(FieldSet)
+        expect(browser.text_field(:id, "new_user_email").parent).to be_instance_of(FieldSet)
       end
 
       it "returns nil if the element has no parent" do
-        browser.body.parent.parent.should be_nil
+        expect(browser.body.parent.parent).to be_nil
       end
     end
   end
 
   describe "#visible?" do
     it "returns true if the element is visible" do
-      browser.text_field(:id, "new_user_email").should be_visible
+      expect(browser.text_field(:id, "new_user_email")).to be_visible
     end
 
     it "returns true if the element has style='visibility: visible' even if parent has style='visibility: hidden'" do
-      browser.div(:id => "visible_child").should be_visible
+      expect(browser.div(:id => "visible_child")).to be_visible
     end
 
-    it "returns false if the element is input element where type == 'hidden'" do
-      browser.hidden(:id, "new_user_interests_dolls").should_not be_visible
+    it "returns false if the element is input element where type eq 'hidden'" do
+      expect(browser.hidden(:id, "new_user_interests_dolls")).to_not be_visible
     end
 
     it "returns false if the element has style='display: none;'" do
-      browser.div(:id, 'changed_language').should_not be_visible
+      expect(browser.div(:id, 'changed_language')).to_not be_visible
     end
 
     it "returns false if the element has style='visibility: hidden;" do
-      browser.div(:id, 'wants_newsletter').should_not be_visible
+      expect(browser.div(:id, 'wants_newsletter')).to_not be_visible
     end
 
     it "returns false if one of the parent elements is hidden" do
-      browser.div(:id, 'hidden_parent').should_not be_visible
+      expect(browser.div(:id, 'hidden_parent')).to_not be_visible
     end
   end
 
@@ -187,36 +187,36 @@ describe "Element" do
 
       it "matches when the element has a single class" do
         e = browser.div(:class => "a")
-        e.should exist
-        e.class_name.should == "a"
+        expect(e).to exist
+        expect(e.class_name).to eq "a"
       end
 
       it "matches when the element has several classes" do
         e = browser.div(:class => "b")
-        e.should exist
-        e.class_name.should == "a b"
+        expect(e).to exist
+        expect(e.class_name).to eq "a b"
       end
 
       it "does not match only part of the class name" do
-        browser.div(:class => "c").should_not exist
+        expect(browser.div(:class => "c")).to_not exist
       end
 
       it "matches part of the class name when given a regexp" do
-        browser.div(:class => /c/).should exist
+        expect(browser.div(:class => /c/)).to exist
       end
     end
 
     it "doesn't raise when called on nested elements" do
-      browser.div(:id, 'no_such_div').link(:id, 'no_such_id').should_not exist
+      expect(browser.div(:id, 'no_such_div').link(:id, 'no_such_id')).to_not exist
     end
 
     it "raises ArgumentError error if selector hash with :xpath has multiple entries" do
-      lambda { browser.div(:xpath => "//div", :class => "foo").exists? }.should raise_error(ArgumentError)
+      expect{ browser.div(:xpath => "//div", :class => "foo").exists? }.to raise_error(ArgumentError)
     end
 
     bug "https://github.com/watir/watir-webdriver/issues/124", :webdriver do
       it "raises ArgumentError error if selector hash with :css has multiple entries" do
-        lambda { browser.div(:css => "//div", :class => "foo").exists? }.should raise_error(ArgumentError)
+        expect{ browser.div(:css => "//div", :class => "foo").exists? }.to raise_error(ArgumentError)
       end
     end
   end
@@ -232,14 +232,14 @@ describe "Element" do
 
     it 'sends keystrokes to the element' do
       receiver.send_keys 'hello world'
-      receiver.value.should == 'hello world'
-      events.should == 11
+      expect(receiver.value).to eq 'hello world'
+      expect(events).to eq 11
     end
 
     it 'accepts arbitrary list of arguments' do
       receiver.send_keys 'hello', 'world'
-      receiver.value.should == 'helloworld'
-      events.should == 10
+      expect(receiver.value).to eq 'helloworld'
+      expect(events).to eq 10
     end
 
     # key combinations probably not ever possible on mobile devices?
@@ -248,21 +248,21 @@ describe "Element" do
         receiver.send_keys 'foo'
         receiver.send_keys [@c, 'a']
         receiver.send_keys :backspace
-        receiver.value.should be_empty
-        events.should == 6
+        expect(receiver.value).to be_empty
+        expect(events).to eq 6
       end
 
       it 'performs arbitrary list of key combinations' do
         receiver.send_keys 'foo'
         receiver.send_keys [@c, 'a'], [@c, 'x']
-        receiver.value.should be_empty
-        events.should == 7
+        expect(receiver.value).to be_empty
+        expect(events).to eq 7
       end
 
       it 'supports combination of strings and arrays' do
         receiver.send_keys 'foo', [@c, 'a'], :backspace
-        receiver.value.should be_empty
-        events.should == 6
+        expect(receiver.value).to be_empty
+        expect(events).to eq 6
       end
     end
   end
@@ -272,7 +272,7 @@ describe "Element" do
     let(:h2) { browser.h2(:text => 'Add user') }
 
     it 'returns the element on which it was called' do
-      h2.flash.should == h2
+      expect(h2.flash).to eq h2
     end
   end
 end

--- a/em_spec.rb
+++ b/em_spec.rb
@@ -10,91 +10,91 @@ describe "Em" do
   # Exists method
   describe "#exists?" do
     it "returns true if the element exists" do
-      browser.em(:id, "important-id").should exist
-      browser.em(:class, "important-class").should exist
-      browser.em(:xpath, "//em[@id='important-id']").should exist
-      browser.em(:index, 0).should exist
+      expect(browser.em(:id, "important-id")).to exist
+      expect(browser.em(:class, "important-class")).to exist
+      expect(browser.em(:xpath, "//em[@id='important-id']")).to exist
+      expect(browser.em(:index, 0)).to exist
     end
 
     it "returns the first em if given no args" do
-      browser.em.should exist
+      expect(browser.em).to exist
     end
 
     it "returns false if the element does not exist" do
-      browser.em(:id, "no_such_id").should_not exist
+      expect(browser.em(:id, "no_such_id")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.em(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.em(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.em(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.em(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Attribute methods
   describe "#class_name" do
     it "returns the class attribute if the element exists" do
-      browser.em(:id, "important-id").class_name.should == "important-class"
+      expect(browser.em(:id, "important-id").class_name).to eq "important-class"
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      lambda { browser.em(:id, "no_such_id").class_name }.should raise_error(UnknownObjectException)
-      lambda { browser.em(:title, "no_such_title").class_name }.should raise_error(UnknownObjectException)
-      lambda { browser.em(:index, 1337).class_name }.should raise_error(UnknownObjectException)
-      lambda { browser.em(:xpath, "//em[@id='no_such_id']").class_name }.should raise_error(UnknownObjectException)
+      expect{ browser.em(:id, "no_such_id").class_name }.to raise_error(UnknownObjectException)
+      expect{ browser.em(:title, "no_such_title").class_name }.to raise_error(UnknownObjectException)
+      expect{ browser.em(:index, 1337).class_name }.to raise_error(UnknownObjectException)
+      expect{ browser.em(:xpath, "//em[@id='no_such_id']").class_name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#id" do
     it "returns the id attribute if the element exists" do
-      browser.em(:class, 'important-class').id.should == "important-id"
+      expect(browser.em(:class, 'important-class').id).to eq "important-id"
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      lambda {browser.em(:id, "no_such_id").id }.should raise_error(UnknownObjectException)
-      lambda {browser.em(:title, "no_such_id").id }.should raise_error(UnknownObjectException)
-      lambda {browser.em(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{browser.em(:id, "no_such_id").id }.to raise_error(UnknownObjectException)
+      expect{browser.em(:title, "no_such_id").id }.to raise_error(UnknownObjectException)
+      expect{browser.em(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#title" do
     it "returns the title of the element" do
-      browser.em(:class, "important-class").title.should == "ergo cogito"
+      expect(browser.em(:class, "important-class").title).to eq "ergo cogito"
     end
   end
 
   describe "#text" do
     it "returns the text of the element" do
-      browser.em(:id, "important-id").text.should == "ergo cogito"
+      expect(browser.em(:id, "important-id").text).to eq "ergo cogito"
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      lambda { browser.em(:id, "no_such_id").text }.should raise_error(UnknownObjectException)
-      lambda { browser.em(:title, "no_such_title").text }.should raise_error(UnknownObjectException)
-      lambda { browser.em(:index, 1337).text }.should raise_error(UnknownObjectException)
-      lambda { browser.em(:xpath, "//em[@id='no_such_id']").text }.should raise_error(UnknownObjectException)
+      expect{ browser.em(:id, "no_such_id").text }.to raise_error(UnknownObjectException)
+      expect{ browser.em(:title, "no_such_title").text }.to raise_error(UnknownObjectException)
+      expect{ browser.em(:index, 1337).text }.to raise_error(UnknownObjectException)
+      expect{ browser.em(:xpath, "//em[@id='no_such_id']").text }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.em(:index, 0).should respond_to(:id)
-      browser.em(:index, 0).should respond_to(:class_name)
-      browser.em(:index, 0).should respond_to(:style)
-      browser.em(:index, 0).should respond_to(:text)
-      browser.em(:index, 0).should respond_to(:title)
+      expect(browser.em(:index, 0)).to respond_to(:id)
+      expect(browser.em(:index, 0)).to respond_to(:class_name)
+      expect(browser.em(:index, 0)).to respond_to(:style)
+      expect(browser.em(:index, 0)).to respond_to(:text)
+      expect(browser.em(:index, 0)).to respond_to(:title)
     end
   end
 
   # Manipulation methods
   describe "#click" do
     it "raises UnknownObjectException if the element does not exist" do
-      lambda { browser.em(:id, "no_such_id").click }.should raise_error(UnknownObjectException)
-      lambda { browser.em(:title, "no_such_title").click }.should raise_error(UnknownObjectException)
-      lambda { browser.em(:index, 1337).click }.should raise_error(UnknownObjectException)
-      lambda { browser.em(:xpath, "//em[@id='no_such_id']").click }.should raise_error(UnknownObjectException)
+      expect{ browser.em(:id, "no_such_id").click }.to raise_error(UnknownObjectException)
+      expect{ browser.em(:title, "no_such_title").click }.to raise_error(UnknownObjectException)
+      expect{ browser.em(:index, 1337).click }.to raise_error(UnknownObjectException)
+      expect{ browser.em(:xpath, "//em[@id='no_such_id']").click }.to raise_error(UnknownObjectException)
     end
   end
 

--- a/ems_spec.rb
+++ b/ems_spec.rb
@@ -10,20 +10,20 @@ describe "Ems" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.ems(:class => "important-class").to_a.should == [browser.em(:class => "important-class")]
+        expect(browser.ems(:class => "important-class").to_a).to eq [browser.em(:class => "important-class")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the number of ems" do
-      browser.ems.length.should == 1
+      expect(browser.ems.length).to eq 1
     end
   end
 
   describe "#[]" do
     it "returns the em at the given index" do
-      browser.ems[0].id.should == "important-id"
+      expect(browser.ems[0].id).to eq "important-id"
     end
   end
 
@@ -32,14 +32,14 @@ describe "Ems" do
       count = 0
 
       browser.ems.each_with_index do |e, index|
-        e.text.should == browser.em(:index, index).text
-        e.id.should == browser.em(:index, index).id
-        e.class_name.should == browser.em(:index, index).class_name
+        expect(e.text).to eq browser.em(:index, index).text
+        expect(e.id).to eq browser.em(:index, index).id
+        expect(e.class_name).to eq browser.em(:index, index).class_name
 
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/filefield_spec.rb
+++ b/filefield_spec.rb
@@ -9,41 +9,41 @@ describe "FileField" do
 
   describe "#exist?" do
     it "returns true if the file field exists" do
-      browser.file_field(:id, 'new_user_portrait').should exist
-      browser.file_field(:id, /new_user_portrait/).should exist
-      browser.file_field(:name, 'new_user_portrait').should exist
-      browser.file_field(:name, /new_user_portrait/).should exist
-      browser.file_field(:class, 'portrait').should exist
-      browser.file_field(:class, /portrait/).should exist
-      browser.file_field(:index, 0).should exist
-      browser.file_field(:xpath, "//input[@id='new_user_portrait']").should exist
+      expect(browser.file_field(:id, 'new_user_portrait')).to exist
+      expect(browser.file_field(:id, /new_user_portrait/)).to exist
+      expect(browser.file_field(:name, 'new_user_portrait')).to exist
+      expect(browser.file_field(:name, /new_user_portrait/)).to exist
+      expect(browser.file_field(:class, 'portrait')).to exist
+      expect(browser.file_field(:class, /portrait/)).to exist
+      expect(browser.file_field(:index, 0)).to exist
+      expect(browser.file_field(:xpath, "//input[@id='new_user_portrait']")).to exist
     end
 
     it "returns the first file field if given no args" do
-      browser.file_field.should exist
+      expect(browser.file_field).to exist
     end
 
     it "returns true for element with upper case type" do
-      browser.file_field(:id, "new_user_resume").should exist
+      expect(browser.file_field(:id, "new_user_resume")).to exist
     end
 
     it "returns false if the file field doesn't exist" do
-      browser.file_field(:id, 'no_such_id').should_not exist
-      browser.file_field(:id, /no_such_id/).should_not exist
-      browser.file_field(:name, 'no_such_name').should_not exist
-      browser.file_field(:name, /no_such_name/).should_not exist
-      browser.file_field(:class, 'no_such_class').should_not exist
-      browser.file_field(:class, /no_such_class/).should_not exist
-      browser.file_field(:index, 1337).should_not exist
-      browser.file_field(:xpath, "//input[@id='no_such_id']").should_not exist
+      expect(browser.file_field(:id, 'no_such_id')).to_not exist
+      expect(browser.file_field(:id, /no_such_id/)).to_not exist
+      expect(browser.file_field(:name, 'no_such_name')).to_not exist
+      expect(browser.file_field(:name, /no_such_name/)).to_not exist
+      expect(browser.file_field(:class, 'no_such_class')).to_not exist
+      expect(browser.file_field(:class, /no_such_class/)).to_not exist
+      expect(browser.file_field(:index, 1337)).to_not exist
+      expect(browser.file_field(:xpath, "//input[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.file_field(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.file_field(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.file_field(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.file_field(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
@@ -51,58 +51,58 @@ describe "FileField" do
 
   describe "#class_name" do
     it "returns the class attribute if the text field exists" do
-      browser.file_field(:index, 0).class_name.should == "portrait"
+      expect(browser.file_field(:index, 0).class_name).to eq "portrait"
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      lambda { browser.file_field(:index, 1337).class_name }.should raise_error(UnknownObjectException)
+      expect{ browser.file_field(:index, 1337).class_name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#id" do
     it "returns the id attribute if the text field exists" do
-      browser.file_field(:index, 0).id.should == "new_user_portrait"
+      expect(browser.file_field(:index, 0).id).to eq "new_user_portrait"
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      lambda { browser.file_field(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{ browser.file_field(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#name" do
     it "returns the name attribute if the text field exists" do
-      browser.file_field(:index, 0).name.should == "new_user_portrait"
+      expect(browser.file_field(:index, 0).name).to eq "new_user_portrait"
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      lambda { browser.file_field(:index, 1337).name }.should raise_error(UnknownObjectException)
+      expect{ browser.file_field(:index, 1337).name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#title" do
     it "returns the title attribute if the text field exists" do
-      browser.file_field(:id, "new_user_portrait").title.should == "Smile!"
+      expect(browser.file_field(:id, "new_user_portrait").title).to eq "Smile!"
     end
   end
 
   describe "#type" do
     it "returns the type attribute if the text field exists" do
-      browser.file_field(:index, 0).type.should == "file"
+      expect(browser.file_field(:index, 0).type).to eq "file"
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      lambda { browser.file_field(:index, 1337).type }.should raise_error(UnknownObjectException)
+      expect{ browser.file_field(:index, 1337).type }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.file_field(:index, 0).should respond_to(:class_name)
-      browser.file_field(:index, 0).should respond_to(:id)
-      browser.file_field(:index, 0).should respond_to(:name)
-      browser.file_field(:index, 0).should respond_to(:title)
-      browser.file_field(:index, 0).should respond_to(:type)
-      browser.file_field(:index, 0).should respond_to(:value)
+      expect(browser.file_field(:index, 0)).to respond_to(:class_name)
+      expect(browser.file_field(:index, 0)).to respond_to(:id)
+      expect(browser.file_field(:index, 0)).to respond_to(:name)
+      expect(browser.file_field(:index, 0)).to respond_to(:title)
+      expect(browser.file_field(:index, 0)).to respond_to(:type)
+      expect(browser.file_field(:index, 0)).to respond_to(:value)
     end
   end
 
@@ -110,7 +110,7 @@ describe "FileField" do
 
   describe "#set" do
     not_compliant_on [:webdriver, :iphone] do
-      bug "https://github.com/detro/ghostdriver/issues/183", :phantomjs do 
+      bug "https://github.com/detro/ghostdriver/issues/183", :phantomjs do
         it "is able to set a file path in the field and click the upload button and fire the onchange event" do
           browser.goto WatirSpec.url_for("forms_with_input_elements.html", :needs_server => true)
 
@@ -119,16 +119,16 @@ describe "FileField" do
 
           element.set path
 
-          element.value.should include(File.basename(path)) # only some browser will return the full path
-          messages.first.should include(File.basename(path))
+          expect(element.value).to include(File.basename(path)) # only some browser will return the full path
+          expect(messages.first).to include(File.basename(path))
 
           browser.button(:name, "new_user_submit").click
         end
 
         it "raises an error if the file does not exist" do
-          lambda {
+          expect{
             browser.file_field.set(File.join(Dir.tmpdir, 'unlikely-to-exist'))
-          }.should raise_error(Errno::ENOENT)
+          }.to raise_error(Errno::ENOENT)
         end
       end
     end
@@ -145,7 +145,7 @@ describe "FileField" do
           element = browser.file_field(:name, "new_user_portrait")
 
           element.value = path
-          element.value.should include(File.basename(path)) # only some browser will return the full path
+          expect(element.value).to include(File.basename(path)) # only some browser will return the full path
         end
       end
     end
@@ -160,13 +160,13 @@ describe "FileField" do
           expected = path
           expected.gsub!("/", "\\") if WatirSpec.platform == :windows
 
-          browser.file_field.value.should == expected
+          expect(browser.file_field.value).to eq expected
         end
 
         it "does not alter its argument" do
           value = '/foo/bar'
           browser.file_field.value = value
-          value.should == '/foo/bar'
+          expect(value).to eq '/foo/bar'
         end
       end
     end

--- a/filefields_spec.rb
+++ b/filefields_spec.rb
@@ -10,20 +10,20 @@ describe "FileFields" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.file_fields(:class => "portrait").to_a.should == [browser.file_field(:class => "portrait")]
+        expect(browser.file_fields(:class => "portrait").to_a).to eq [browser.file_field(:class => "portrait")]
       end
     end
   end
 
   describe "#length" do
     it "returns the correct number of file fields" do
-      browser.file_fields.length.should == 3
+      expect(browser.file_fields.length).to eq 3
     end
   end
 
   describe "#[]" do
     it "returns the file field at the given index" do
-      browser.file_fields[0].id.should == "new_user_portrait"
+      expect(browser.file_fields[0].id).to eq "new_user_portrait"
     end
   end
 
@@ -32,14 +32,14 @@ describe "FileFields" do
       count = 0
 
       browser.file_fields.each_with_index do |f, index|
-        f.name.should == browser.file_field(:index, index).name
-        f.id.should ==  browser.file_field(:index, index).id
-        f.value.should == browser.file_field(:index, index).value
+        expect(f.name).to eq browser.file_field(:index, index).name
+        expect(f.id).to eq  browser.file_field(:index, index).id
+        expect(f.value).to eq browser.file_field(:index, index).value
 
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/font_spec.rb
+++ b/font_spec.rb
@@ -9,23 +9,23 @@ describe "Font" do
   
   bug "http://github.com/jarib/celerity/issues#issue/29", :celerity do
     it "finds the font element" do
-      browser.font(:index, 0).should exist
+      expect(browser.font(:index, 0)).to exist
     end
 
     it "knows about the color attribute" do
-      browser.font(:index, 0).color.should == "#ff00ff"
+      expect(browser.font(:index, 0).color).to eq "#ff00ff"
     end
 
     it "knows about the face attribute" do
-      browser.font(:index, 0).face.should == "Helvetica"
+      expect(browser.font(:index, 0).face).to eq "Helvetica"
     end
 
     it "knows about the size attribute" do
-      browser.font(:index, 0).size.should == "12"
+      expect(browser.font(:index, 0).size).to eq "12"
     end
 
     it "finds all font elements" do
-      browser.fonts.size.should == 1
+      expect(browser.fonts.size).to eq 1
     end
   end
 

--- a/form_spec.rb
+++ b/form_spec.rb
@@ -9,50 +9,50 @@ describe "Form" do
 
   describe "#exists?" do
     it "returns true if the form exists" do
-      browser.form(:id, 'new_user').should exist
-      browser.form(:id, /new_user/).should exist
+      expect(browser.form(:id, 'new_user')).to exist
+      expect(browser.form(:id, /new_user/)).to exist
 
-      browser.form(:class, 'user').should exist
-      browser.form(:class, /user/).should exist
+      expect(browser.form(:class, 'user')).to exist
+      expect(browser.form(:class, /user/)).to exist
 
-      browser.form(:method, 'post').should exist
-      browser.form(:method, /post/).should exist
+      expect(browser.form(:method, 'post')).to exist
+      expect(browser.form(:method, /post/)).to exist
       deviates_on :internet_explorer8 do
-        browser.form(:action, 'post_to_me').should exist
+        expect(browser.form(:action, 'post_to_me')).to exist
       end
       deviates_on :internet_explorer9 do
-        browser.form(:action, /post_to_me/).should exist
+        expect(browser.form(:action, /post_to_me/)).to exist
       end
-      browser.form(:action, /to_me/).should exist
-      browser.form(:index, 0).should exist
-      browser.form(:xpath, "//form[@id='new_user']").should exist
+      expect(browser.form(:action, /to_me/)).to exist
+      expect(browser.form(:index, 0)).to exist
+      expect(browser.form(:xpath, "//form[@id='new_user']")).to exist
     end
 
     it "returns the first form if given no args" do
-      browser.form.should exist
+      expect(browser.form).to exist
     end
 
     it "returns false if the form doesn't exist" do
-      browser.form(:id, 'no_such_id').should_not exist
-      browser.form(:id, /no_such_id/).should_not exist
+      expect(browser.form(:id, 'no_such_id')).to_not exist
+      expect(browser.form(:id, /no_such_id/)).to_not exist
 
-      browser.form(:class, 'no_such_class').should_not exist
-      browser.form(:class, /no_such_class/).should_not exist
+      expect(browser.form(:class, 'no_such_class')).to_not exist
+      expect(browser.form(:class, /no_such_class/)).to_not exist
 
-      browser.form(:method, 'no_such_method').should_not exist
-      browser.form(:method, /no_such_method/).should_not exist
-      browser.form(:action, 'no_such_action').should_not exist
-      browser.form(:action, /no_such_action/).should_not exist
-      browser.form(:index, 1337).should_not exist
-      browser.form(:xpath, "//form[@id='no_such_id']").should_not exist
+      expect(browser.form(:method, 'no_such_method')).to_not exist
+      expect(browser.form(:method, /no_such_method/)).to_not exist
+      expect(browser.form(:action, 'no_such_action')).to_not exist
+      expect(browser.form(:action, /no_such_action/)).to_not exist
+      expect(browser.form(:index, 1337)).to_not exist
+      expect(browser.form(:xpath, "//form[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.form(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.form(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.form(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.form(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
@@ -60,15 +60,15 @@ describe "Form" do
     not_compliant_on :celerity do
       it "submits the form" do
         browser.form(:id, "delete_user").submit
-        browser.text.should include("Semantic table")
+        expect(browser.text).to include("Semantic table")
       end
 
       it "triggers onsubmit event and takes its result into account" do
         form = browser.form(:name, "user_new")
-        form.submit  
-        form.should exist
-        messages.size.should == 1
-        messages[0].should == "submit"
+        form.submit
+        expect(form).to exist
+        expect(messages.size).to eq 1
+        expect(messages[0]).to eq "submit"
       end
 
     end

--- a/forms_spec.rb
+++ b/forms_spec.rb
@@ -10,21 +10,21 @@ describe "Forms" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.forms(:method => "post").to_a.should == [browser.form(:method => "post")]
+        expect(browser.forms(:method => "post").to_a).to eq [browser.form(:method => "post")]
       end
     end
   end
 
   describe "#length" do
     it "returns the number of forms in the container" do
-      browser.forms.length.should == 2
+      expect(browser.forms.length).to eq 2
     end
   end
 
   describe "#[]n" do
     it "provides access to the nth form" do
-      browser.forms[0].action.should =~ /post_to_me$/ # varies between browsers
-      browser.forms[0].attribute_value('method').should == 'post'
+      expect(browser.forms[0].action).to match(/post_to_me$/) # varies between browsers
+      expect(browser.forms[0].attribute_value('method')).to eq 'post'
     end
   end
 
@@ -33,14 +33,14 @@ describe "Forms" do
       count = 0
 
       browser.forms.each_with_index do |f, index|
-        f.name.should == browser.form(:index, index).name
-        f.id.should == browser.form(:index, index).id
-        f.class_name.should == browser.form(:index, index).class_name
+        expect(f.name).to eq browser.form(:index, index).name
+        expect(f.id).to eq browser.form(:index, index).id
+        expect(f.class_name).to eq browser.form(:index, index).class_name
 
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/frame_spec.rb
+++ b/frame_spec.rb
@@ -14,46 +14,46 @@ describe "Frame" do
   it "handles crossframe javascript" do
     browser.goto WatirSpec.url_for("frames.html", :needs_server => true)
 
-    browser.frame(:id, "frame_1").text_field(:name, 'senderElement').value.should == 'send_this_value'
-    browser.frame(:id, "frame_2").text_field(:name, 'recieverElement').value.should == 'old_value'
+    expect(browser.frame(:id, "frame_1").text_field(:name, 'senderElement').value).to eq 'send_this_value'
+    expect(browser.frame(:id, "frame_2").text_field(:name, 'recieverElement').value).to eq 'old_value'
     browser.frame(:id, "frame_1").button(:id, 'send').click
-    browser.frame(:id, "frame_2").text_field(:name, 'recieverElement').value.should == 'send_this_value'
+    expect(browser.frame(:id, "frame_2").text_field(:name, 'recieverElement').value).to eq 'send_this_value'
   end
 
   describe "#exist?" do
     it "returns true if the frame exists" do
-      browser.frame(:id, "frame_1").should exist
-      browser.frame(:name, "frame1").should exist
-      browser.frame(:index, 0).should exist
-      browser.frame(:class, "half").should exist
+      expect(browser.frame(:id, "frame_1")).to exist
+      expect(browser.frame(:name, "frame1")).to exist
+      expect(browser.frame(:index, 0)).to exist
+      expect(browser.frame(:class, "half")).to exist
       not_compliant_on [:watir_classic, :internet_explorer10] do
-        browser.frame(:xpath, "//frame[@id='frame_1']").should exist
+        expect(browser.frame(:xpath, "//frame[@id='frame_1']")).to exist
       end
       not_compliant_on :watir_classic do
-        browser.frame(:src, "frame_1.html").should exist
+        expect(browser.frame(:src, "frame_1.html")).to exist
       end
-      browser.frame(:id, /frame/).should exist
-      browser.frame(:name, /frame/).should exist
-      browser.frame(:src, /frame_1/).should exist
-      browser.frame(:class, /half/).should exist
+      expect(browser.frame(:id, /frame/)).to exist
+      expect(browser.frame(:name, /frame/)).to exist
+      expect(browser.frame(:src, /frame_1/)).to exist
+      expect(browser.frame(:class, /half/)).to exist
     end
 
     it "returns the first frame if given no args" do
-      browser.frame.should exist
+      expect(browser.frame).to exist
     end
 
     it "returns false if the frame doesn't exist" do
-      browser.frame(:id, "no_such_id").should_not exist
-      browser.frame(:name, "no_such_text").should_not exist
-      browser.frame(:index, 1337).should_not exist
+      expect(browser.frame(:id, "no_such_id")).to_not exist
+      expect(browser.frame(:name, "no_such_text")).to_not exist
+      expect(browser.frame(:index, 1337)).to_not exist
 
-      browser.frame(:src, "no_such_src").should_not exist
-      browser.frame(:class, "no_such_class").should_not exist
-      browser.frame(:id, /no_such_id/).should_not exist
-      browser.frame(:name, /no_such_text/).should_not exist
-      browser.frame(:src, /no_such_src/).should_not exist
-      browser.frame(:class, /no_such_class/).should_not exist
-      browser.frame(:xpath, "//frame[@id='no_such_id']").should_not exist
+      expect(browser.frame(:src, "no_such_src")).to_not exist
+      expect(browser.frame(:class, "no_such_class")).to_not exist
+      expect(browser.frame(:id, /no_such_id/)).to_not exist
+      expect(browser.frame(:name, /no_such_text/)).to_not exist
+      expect(browser.frame(:src, /no_such_src/)).to_not exist
+      expect(browser.frame(:class, /no_such_class/)).to_not exist
+      expect(browser.frame(:xpath, "//frame[@id='no_such_id']")).to_not exist
     end
 
     bug "https://github.com/detro/ghostdriver/issues/159", :phantomjs do
@@ -62,56 +62,56 @@ describe "Frame" do
 
         browser.frame(:id, "two").frame(:id, "three").link(:id => "four").click
 
-        Wait.until { browser.title == "definition_lists" }
+        Wait.until{ browser.title == "definition_lists" }
       end
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.frame(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.frame(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.frame(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.frame(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   it "raises UnknownFrameException when accessing elements inside non-existing frame" do
-    lambda { browser.frame(:name, "no_such_name").p(:index, 0).id }.should raise_error(UnknownFrameException)
+    expect{ browser.frame(:name, "no_such_name").p(:index, 0).id }.to raise_error(UnknownFrameException)
   end
 
   it "raises UnknownFrameException when accessing a non-existing frame" do
-    lambda { browser.frame(:name, "no_such_name").id }.should raise_error(UnknownFrameException)
+    expect{ browser.frame(:name, "no_such_name").id }.to raise_error(UnknownFrameException)
   end
 
   it "raises UnknownFrameException when accessing a non-existing subframe" do
-    lambda { browser.frame(:name, "frame1").frame(:name, "no_such_name").id }.should raise_error(UnknownFrameException)
+    expect{ browser.frame(:name, "frame1").frame(:name, "no_such_name").id }.to raise_error(UnknownFrameException)
   end
 
   it "raises UnknownObjectException when accessing a non-existing element inside an existing frame" do
-    lambda { browser.frame(:index, 0).p(:index, 1337).id }.should raise_error(UnknownObjectException)
+    expect{ browser.frame(:index, 0).p(:index, 1337).id }.to raise_error(UnknownObjectException)
   end
 
   it "raises NoMethodError when trying to access attributes it doesn't have" do
-    lambda { browser.frame(:index, 0).foo }.should raise_error(NoMethodError)
+    expect{ browser.frame(:index, 0).foo }.to raise_error(NoMethodError)
   end
 
   it "is able to set a field" do
     browser.frame(:index, 0).text_field(:name, 'senderElement').set("new value")
-    browser.frame(:index, 0).text_field(:name, 'senderElement').value.should == "new value"
+    expect(browser.frame(:index, 0).text_field(:name, 'senderElement').value).to eq "new value"
   end
 
   it "can access the frame's parent element after use" do
     el = browser.frameset
     el.frame.text_field.value
-    el.attribute_value("cols").should be_kind_of(String)
+    expect(el.attribute_value("cols")).to be_kind_of(String)
   end
 
   describe "#execute_script" do
     it "executes the given javascript in the specified frame" do
       frame = browser.frame(:index, 0)
-      frame.div(:id, 'set_by_js').text.should == ""
+      expect(frame.div(:id, 'set_by_js').text).to eq ""
       frame.execute_script(%Q{document.getElementById('set_by_js').innerHTML = 'Art consists of limitation. The most beautiful part of every picture is the frame.'})
-      frame.div(:id, 'set_by_js').text.should == "Art consists of limitation. The most beautiful part of every picture is the frame."
+      expect(frame.div(:id, 'set_by_js').text).to eq "Art consists of limitation. The most beautiful part of every picture is the frame."
     end
   end
 
@@ -119,7 +119,7 @@ describe "Frame" do
     not_compliant_on [:webdriver, :iphone] do
       it "returns the full HTML source of the frame" do
         browser.goto WatirSpec.url_for("frames.html")
-        browser.frame.html.downcase.should include("<title>frame 1</title>")
+        expect(browser.frame.html.downcase).to include("<title>frame 1</title>")
       end
     end
   end

--- a/frames_spec.rb
+++ b/frames_spec.rb
@@ -10,20 +10,20 @@ describe "Frames" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.frames(:name => "frame1").to_a.should == [browser.frame(:name => "frame1")]
+        expect(browser.frames(:name => "frame1").to_a).to eq [browser.frame(:name => "frame1")]
       end
     end
   end
 
   describe "#length" do
     it "returns the correct number of frames" do
-      browser.frames.length.should == 2
+      expect(browser.frames.length).to eq 2
     end
   end
 
   describe "#[]" do
     it "returns the frame at the given index" do
-      browser.frames[0].id.should == "frame_1"
+      expect(browser.frames[0].id).to eq "frame_1"
     end
   end
 
@@ -32,12 +32,12 @@ describe "Frames" do
       count = 0
 
       browser.frames.each_with_index do |f, index|
-        f.name.should == browser.frame(:index, index).name
-        f.id.should == browser.frame(:index, index).id
+        expect(f.name).to eq browser.frame(:index, index).name
+        expect(f.id).to eq browser.frame(:index, index).id
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 end

--- a/hidden_spec.rb
+++ b/hidden_spec.rb
@@ -10,93 +10,93 @@ describe "Hidden" do
   # Exist method
   describe "#exists?" do
     it "returns true if the element exists" do
-      browser.hidden(:id, 'new_user_interests_dolls').should exist
-      browser.hidden(:id, /new_user_interests_dolls/).should exist
-      browser.hidden(:name, 'new_user_interests').should exist
-      browser.hidden(:name, /new_user_interests/).should exist
-      browser.hidden(:value, 'dolls').should exist
-      browser.hidden(:value, /dolls/).should exist
-      browser.hidden(:class, 'fun').should exist
-      browser.hidden(:class, /fun/).should exist
-      browser.hidden(:index, 0).should exist
-      browser.hidden(:xpath, "//input[@id='new_user_interests_dolls']").should exist
+      expect(browser.hidden(:id, 'new_user_interests_dolls')).to exist
+      expect(browser.hidden(:id, /new_user_interests_dolls/)).to exist
+      expect(browser.hidden(:name, 'new_user_interests')).to exist
+      expect(browser.hidden(:name, /new_user_interests/)).to exist
+      expect(browser.hidden(:value, 'dolls')).to exist
+      expect(browser.hidden(:value, /dolls/)).to exist
+      expect(browser.hidden(:class, 'fun')).to exist
+      expect(browser.hidden(:class, /fun/)).to exist
+      expect(browser.hidden(:index, 0)).to exist
+      expect(browser.hidden(:xpath, "//input[@id='new_user_interests_dolls']")).to exist
     end
 
     it "returns the first hidden if given no args" do
-      browser.hidden.should exist
+      expect(browser.hidden).to exist
     end
 
     it "returns false if the element does not exist" do
-      browser.hidden(:id, 'no_such_id').should_not exist
-      browser.hidden(:id, /no_such_id/).should_not exist
-      browser.hidden(:name, 'no_such_name').should_not exist
-      browser.hidden(:name, /no_such_name/).should_not exist
-      browser.hidden(:value, 'no_such_value').should_not exist
-      browser.hidden(:value, /no_such_value/).should_not exist
-      browser.hidden(:text, 'no_such_text').should_not exist
-      browser.hidden(:text, /no_such_text/).should_not exist
-      browser.hidden(:class, 'no_such_class').should_not exist
-      browser.hidden(:class, /no_such_class/).should_not exist
-      browser.hidden(:index, 1337).should_not exist
-      browser.hidden(:xpath, "//input[@id='no_such_id']").should_not exist
+      expect(browser.hidden(:id, 'no_such_id')).to_not exist
+      expect(browser.hidden(:id, /no_such_id/)).to_not exist
+      expect(browser.hidden(:name, 'no_such_name')).to_not exist
+      expect(browser.hidden(:name, /no_such_name/)).to_not exist
+      expect(browser.hidden(:value, 'no_such_value')).to_not exist
+      expect(browser.hidden(:value, /no_such_value/)).to_not exist
+      expect(browser.hidden(:text, 'no_such_text')).to_not exist
+      expect(browser.hidden(:text, /no_such_text/)).to_not exist
+      expect(browser.hidden(:class, 'no_such_class')).to_not exist
+      expect(browser.hidden(:class, /no_such_class/)).to_not exist
+      expect(browser.hidden(:index, 1337)).to_not exist
+      expect(browser.hidden(:xpath, "//input[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.hidden(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.hidden(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.hidden(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.hidden(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Attribute methods
   describe "#id" do
     it "returns the id attribute if the text field exists" do
-      browser.hidden(:index, 0).id.should == "new_user_interests_dolls"
+      expect(browser.hidden(:index, 0).id).to eq "new_user_interests_dolls"
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      lambda { browser.hidden(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{ browser.hidden(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#name" do
     it "returns the name attribute if the text field exists" do
-      browser.hidden(:index, 0).name.should == "new_user_interests"
+      expect(browser.hidden(:index, 0).name).to eq "new_user_interests"
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      lambda { browser.hidden(:index, 1337).name }.should raise_error(UnknownObjectException)
+      expect{ browser.hidden(:index, 1337).name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#type" do
     it "returns the type attribute if the text field exists" do
-      browser.hidden(:index, 0).type.should == "hidden"
+      expect(browser.hidden(:index, 0).type).to eq "hidden"
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      lambda { browser.hidden(:index, 1337).type }.should raise_error(UnknownObjectException)
+      expect{ browser.hidden(:index, 1337).type }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#value" do
     it "returns the value attribute if the text field exists" do
-      browser.hidden(:index, 0).value.should == "dolls"
+      expect(browser.hidden(:index, 0).value).to eq "dolls"
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      lambda { browser.hidden(:index, 1337).value }.should raise_error(UnknownObjectException)
+      expect{ browser.hidden(:index, 1337).value }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.hidden(:index, 0).should respond_to(:id)
-      browser.hidden(:index, 0).should respond_to(:name)
-      browser.hidden(:index, 0).should respond_to(:type)
-      browser.hidden(:index, 0).should respond_to(:value)
+      expect(browser.hidden(:index, 0)).to respond_to(:id)
+      expect(browser.hidden(:index, 0)).to respond_to(:name)
+      expect(browser.hidden(:index, 0)).to respond_to(:type)
+      expect(browser.hidden(:index, 0)).to respond_to(:value)
     end
   end
 

--- a/hiddens_spec.rb
+++ b/hiddens_spec.rb
@@ -10,20 +10,20 @@ describe "Hiddens" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.hiddens(:value => "dolls").to_a.should == [browser.hidden(:value => "dolls")]
+        expect(browser.hiddens(:value => "dolls").to_a).to eq [browser.hidden(:value => "dolls")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the number of hiddens" do
-      browser.hiddens.length.should == 1
+      expect(browser.hiddens.length).to eq 1
     end
   end
 
   describe "#[]" do
     it "returns the Hidden at the given index" do
-      browser.hiddens[0].id.should == "new_user_interests_dolls"
+      expect(browser.hiddens[0].id).to eq "new_user_interests_dolls"
     end
   end
 
@@ -32,14 +32,14 @@ describe "Hiddens" do
       count = 0
 
       browser.hiddens.each_with_index do |h, index|
-        h.name.should == browser.hidden(:index, index).name
-        h.id.should == browser.hidden(:index, index).id
-        h.value.should == browser.hidden(:index, index).value
+        expect(h.name).to eq browser.hidden(:index, index).name
+        expect(h.id).to eq browser.hidden(:index, index).id
+        expect(h.value).to eq browser.hidden(:index, index).value
 
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/hn_spec.rb
+++ b/hn_spec.rb
@@ -10,87 +10,87 @@ describe "H1", "H2", "H3", "H4", "H5", "H6" do
   # Exists method
   describe "#exist?" do
     it "returns true if the element exists" do
-      browser.h1(:id, "header1").should exist
-      browser.h2(:id, /header2/).should exist
-      browser.h3(:text, "Header 3").should exist
-      browser.h4(:text, /Header 4/).should exist
-      browser.h5(:index, 0).should exist
-      browser.h6(:index, 0).should exist
-      browser.h1(:xpath, "//h1[@id='first_header']").should exist
+      expect(browser.h1(:id, "header1")).to exist
+      expect(browser.h2(:id, /header2/)).to exist
+      expect(browser.h3(:text, "Header 3")).to exist
+      expect(browser.h4(:text, /Header 4/)).to exist
+      expect(browser.h5(:index, 0)).to exist
+      expect(browser.h6(:index, 0)).to exist
+      expect(browser.h1(:xpath, "//h1[@id='first_header']")).to exist
     end
 
     it "returns the first h1 if given no args" do
-      browser.h1.should exist
+      expect(browser.h1).to exist
     end
 
     it "returns true if the element exists" do
-      browser.h1(:id, "no_such_id").should_not exist
-      browser.h1(:id, /no_such_id/).should_not exist
-      browser.h1(:text, "no_such_text").should_not exist
-      browser.h1(:text, /no_such_text 1/).should_not exist
-      browser.h1(:index, 1337).should_not exist
-      browser.h1(:xpath, "//p[@id='no_such_id']").should_not exist
+      expect(browser.h1(:id, "no_such_id")).to_not exist
+      expect(browser.h1(:id, /no_such_id/)).to_not exist
+      expect(browser.h1(:text, "no_such_text")).to_not exist
+      expect(browser.h1(:text, /no_such_text 1/)).to_not exist
+      expect(browser.h1(:index, 1337)).to_not exist
+      expect(browser.h1(:xpath, "//p[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.h1(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.h1(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.h1(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.h1(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Attribute methods
   describe "#class_name" do
     it "returns the class attribute" do
-      browser.h1(:index, 0).class_name.should == 'primary'
+      expect(browser.h1(:index, 0).class_name).to eq 'primary'
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.h2(:index, 0).class_name.should == ''
+      expect(browser.h2(:index, 0).class_name).to eq ''
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      lambda { browser.h2(:id, 'no_such_id').class_name }.should raise_error(UnknownObjectException)
+      expect{ browser.h2(:id, 'no_such_id').class_name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#id" do
     it "returns the id attribute" do
-      browser.h1(:index, 0).id.should == "first_header"
+      expect(browser.h1(:index, 0).id).to eq "first_header"
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.h3(:index, 0).id.should == ''
+      expect(browser.h3(:index, 0).id).to eq ''
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      lambda { browser.h1(:id, "no_such_id").id }.should raise_error(UnknownObjectException)
-      lambda { browser.h1(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{ browser.h1(:id, "no_such_id").id }.to raise_error(UnknownObjectException)
+      expect{ browser.h1(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#text" do
     it "returns the text of the element" do
-      browser.h1(:index, 0).text.should == 'Header 1'
+      expect(browser.h1(:index, 0).text).to eq 'Header 1'
     end
 
     it "returns an empty string if the element doesn't contain any text" do
-      browser.h6(:id, "empty_header").text.should == ''
+      expect(browser.h6(:id, "empty_header").text).to eq ''
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      lambda { browser.h1(:id, 'no_such_id').text }.should raise_error(UnknownObjectException)
-      lambda { browser.h1(:xpath , "//h1[@id='no_such_id']").text }.should raise_error(UnknownObjectException)
+      expect{ browser.h1(:id, 'no_such_id').text }.to raise_error(UnknownObjectException)
+      expect{ browser.h1(:xpath , "//h1[@id='no_such_id']").text }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.h1(:index, 0).should respond_to(:class_name)
-      browser.h1(:index, 0).should respond_to(:id)
-      browser.h1(:index, 0).should respond_to(:text)
+      expect(browser.h1(:index, 0)).to respond_to(:class_name)
+      expect(browser.h1(:index, 0)).to respond_to(:id)
+      expect(browser.h1(:index, 0)).to respond_to(:text)
     end
   end
 

--- a/hns_spec.rb
+++ b/hns_spec.rb
@@ -9,20 +9,20 @@ describe "H1s", "H2s", "H3s", "H4s", "H5s", "H6s" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.h1s(:class => "primary").to_a.should == [browser.h1(:class => "primary")]
+        expect(browser.h1s(:class => "primary").to_a).to eq [browser.h1(:class => "primary")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the number of h1s" do
-      browser.h2s.length.should == 9
+      expect(browser.h2s.length).to eq 9
     end
   end
 
   describe "#[]" do
     it "returns the h1 at the given index" do
-      browser.h1s[0].id.should == "first_header"
+      expect(browser.h1s[0].id).to eq "first_header"
     end
   end
 
@@ -31,11 +31,11 @@ describe "H1s", "H2s", "H3s", "H4s", "H5s", "H6s" do
       lengths = (1..6).collect do |i|
         collection = browser.send(:"h#{i}s")
         collection.each_with_index do |h, index|
-          h.id.should == browser.send(:"h#{i}", :index, index).id
+          expect(h.id).to eq browser.send(:"h#{i}", :index, index).id
         end
         collection.length
       end
-      lengths.should == [2, 9, 2, 1, 1, 2]
+      expect(lengths).to eq [2, 9, 2, 1, 1, 2]
     end
   end
 end

--- a/iframe_spec.rb
+++ b/iframe_spec.rb
@@ -14,45 +14,45 @@ describe "IFrame" do
   it "handles crossframe javascript" do
     browser.goto WatirSpec.url_for("iframes.html", :needs_server => true)
 
-    browser.iframe(:id, "iframe_1").text_field(:name, 'senderElement').value.should == 'send_this_value'
-    browser.iframe(:id, "iframe_2").text_field(:name, 'recieverElement').value.should == 'old_value'
+    expect(browser.iframe(:id, "iframe_1").text_field(:name, 'senderElement').value).to eq 'send_this_value'
+    expect(browser.iframe(:id, "iframe_2").text_field(:name, 'recieverElement').value).to eq 'old_value'
     browser.iframe(:id, "iframe_1").button(:id, 'send').click
-    browser.iframe(:id, "iframe_2").text_field(:name, 'recieverElement').value.should == 'send_this_value'
+    expect(browser.iframe(:id, "iframe_2").text_field(:name, 'recieverElement').value).to eq 'send_this_value'
   end
 
   describe "#exist?" do
     it "returns true if the iframe exists" do
-      browser.iframe(:id, "iframe_1").should exist
-      browser.iframe(:name, "iframe1").should exist
-      browser.iframe(:index, 0).should exist
-      browser.iframe(:class, "half").should exist
+      expect(browser.iframe(:id, "iframe_1")).to exist
+      expect(browser.iframe(:name, "iframe1")).to exist
+      expect(browser.iframe(:index, 0)).to exist
+      expect(browser.iframe(:class, "half")).to exist
       not_compliant_on [:watir_classic, :internet_explorer10] do
-        browser.iframe(:xpath, "//iframe[@id='iframe_1']").should exist
+        expect(browser.iframe(:xpath, "//iframe[@id='iframe_1']")).to exist
       end
       not_compliant_on :watir_classic do
-        browser.iframe(:src, "iframe_1.html").should exist
+        expect(browser.iframe(:src, "iframe_1.html")).to exist
       end
-      browser.iframe(:id, /iframe/).should exist
-      browser.iframe(:name, /iframe/).should exist
-      browser.iframe(:src, /iframe_1/).should exist
-      browser.iframe(:class, /half/).should exist
+      expect(browser.iframe(:id, /iframe/)).to exist
+      expect(browser.iframe(:name, /iframe/)).to exist
+      expect(browser.iframe(:src, /iframe_1/)).to exist
+      expect(browser.iframe(:class, /half/)).to exist
     end
 
     it "returns the first iframe if given no args" do
-      browser.iframe.should exist
+      expect(browser.iframe).to exist
     end
 
     it "returns false if the iframe doesn't exist" do
-      browser.iframe(:id, "no_such_id").should_not exist
-      browser.iframe(:name, "no_such_text").should_not exist
-      browser.iframe(:index, 1337).should_not exist
-      browser.iframe(:src, "no_such_src").should_not exist
-      browser.iframe(:class, "no_such_class").should_not exist
-      browser.iframe(:id, /no_such_id/).should_not exist
-      browser.iframe(:name, /no_such_text/).should_not exist
-      browser.iframe(:src, /no_such_src/).should_not exist
-      browser.iframe(:class, /no_such_class/).should_not exist
-      browser.iframe(:xpath, "//iframe[@id='no_such_id']").should_not exist
+      expect(browser.iframe(:id, "no_such_id")).to_not exist
+      expect(browser.iframe(:name, "no_such_text")).to_not exist
+      expect(browser.iframe(:index, 1337)).to_not exist
+      expect(browser.iframe(:src, "no_such_src")).to_not exist
+      expect(browser.iframe(:class, "no_such_class")).to_not exist
+      expect(browser.iframe(:id, /no_such_id/)).to_not exist
+      expect(browser.iframe(:name, /no_such_text/)).to_not exist
+      expect(browser.iframe(:src, /no_such_src/)).to_not exist
+      expect(browser.iframe(:class, /no_such_class/)).to_not exist
+      expect(browser.iframe(:xpath, "//iframe[@id='no_such_id']")).to_not exist
     end
 
     bug "https://github.com/detro/ghostdriver/issues/159", :phantomjs do
@@ -61,56 +61,56 @@ describe "IFrame" do
 
         browser.iframe(:id, "two").iframe(:id, "three").link(:id => "four").click
 
-        Wait.until { browser.title == "definition_lists" }
+        Wait.until{ browser.title == "definition_lists" }
       end
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.iframe(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.iframe(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.iframe(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.iframe(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   bug 'https://github.com/watir/watir-webdriver/issues/211', :webdriver do
     it 'properly handles all locators for element which do not exist' do
-      browser.iframe(:index, 0).div(:id, 'invalid').should_not exist
+      expect(browser.iframe(:index, 0).div(:id, 'invalid')).to_not exist
     end
   end
 
   it "raises UnknownFrameException when accessing elements inside non-existing iframe" do
-    lambda { browser.iframe(:name, "no_such_name").p(:index, 0).id }.should raise_error(UnknownFrameException)
+    expect{ browser.iframe(:name, "no_such_name").p(:index, 0).id }.to raise_error(UnknownFrameException)
   end
 
   it "raises UnknownFrameException when accessing a non-existing iframe" do
-    lambda { browser.iframe(:name, "no_such_name").id }.should raise_error(UnknownFrameException)
+    expect{ browser.iframe(:name, "no_such_name").id }.to raise_error(UnknownFrameException)
   end
 
   it "raises UnknownFrameException when accessing a non-existing subframe" do
-    lambda { browser.iframe(:name, "iframe1").iframe(:name, "no_such_name").id }.should raise_error(UnknownFrameException)
+    expect{ browser.iframe(:name, "iframe1").iframe(:name, "no_such_name").id }.to raise_error(UnknownFrameException)
   end
 
   it "raises UnknownObjectException when accessing a non-existing element inside an existing iframe" do
-    lambda { browser.iframe(:index, 0).p(:index, 1337).id }.should raise_error(UnknownObjectException)
+    expect{ browser.iframe(:index, 0).p(:index, 1337).id }.to raise_error(UnknownObjectException)
   end
 
   it "raises NoMethodError when trying to access attributes it doesn't have" do
-    lambda { browser.iframe(:index, 0).foo }.should raise_error(NoMethodError)
+    expect{ browser.iframe(:index, 0).foo }.to raise_error(NoMethodError)
   end
 
   it "is able to set a field" do
     browser.iframe(:index, 0).text_field(:name, 'senderElement').set("new value")
-    browser.iframe(:index, 0).text_field(:name, 'senderElement').value.should == "new value"
+    expect(browser.iframe(:index, 0).text_field(:name, 'senderElement').value).to eq "new value"
   end
 
   describe "#execute_script" do
     it "executes the given javascript in the specified frame" do
       frame = browser.iframe(:index, 0)
-      frame.div(:id, 'set_by_js').text.should == ""
+      expect(frame.div(:id, 'set_by_js').text).to eq ""
       frame.execute_script(%Q{document.getElementById('set_by_js').innerHTML = 'Art consists of limitation. The most beautiful part of every picture is the frame.'})
-      frame.div(:id, 'set_by_js').text.should == "Art consists of limitation. The most beautiful part of every picture is the frame."
+      expect(frame.div(:id, 'set_by_js').text).to eq "Art consists of limitation. The most beautiful part of every picture is the frame."
     end
   end
 
@@ -118,7 +118,7 @@ describe "IFrame" do
     not_compliant_on [:webdriver, :iphone] do
       it "returns the full HTML source of the iframe" do
         browser.goto WatirSpec.url_for("iframes.html")
-        browser.iframe.html.downcase.should include("<title>iframe 1</title>")
+        expect(browser.iframe.html.downcase).to include("<title>iframe 1</title>")
       end
     end
   end

--- a/iframes_spec.rb
+++ b/iframes_spec.rb
@@ -9,13 +9,13 @@ describe "IFrames" do
 
   describe "#length" do
     it "returns the correct number of iframes" do
-      browser.iframes.length.should == 2
+      expect(browser.iframes.length).to eq 2
     end
   end
 
   describe "#[]" do
     it "returns the iframe at the given index" do
-      browser.iframes[0].id.should == "iframe_1"
+      expect(browser.iframes[0].id).to eq "iframe_1"
     end
   end
 
@@ -24,12 +24,12 @@ describe "IFrames" do
       count = 0
 
       browser.iframes.each_with_index do |f, index|
-        f.name.should == browser.iframe(:index, index).name
-        f.id.should == browser.iframe(:index, index).id
+        expect(f.name).to eq browser.iframe(:index, index).name
+        expect(f.id).to eq browser.iframe(:index, index).id
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 end

--- a/image_spec.rb
+++ b/image_spec.rb
@@ -10,121 +10,121 @@ describe "Image" do
   # Exists method
   describe "#exists?" do
     it "returns true when the image exists" do
-      browser.image(:id, 'square').should exist
-      browser.image(:id, /square/).should exist
+      expect(browser.image(:id, 'square')).to exist
+      expect(browser.image(:id, /square/)).to exist
 
       not_compliant_on :watir_classic do
-        browser.image(:src, 'images/circle.png').should exist
+        expect(browser.image(:src, 'images/circle.png')).to exist
       end
 
       deviates_on :watir_classic do
-        browser.image(:src, %r{images/circle.png}).should exist
+        expect(browser.image(:src, %r{images/circle.png})).to exist
       end
 
-      browser.image(:src, /circle/).should exist
-      browser.image(:alt, 'circle').should exist
-      browser.image(:alt, /cir/).should exist
-      browser.image(:title, 'Circle').should exist
+      expect(browser.image(:src, /circle/)).to exist
+      expect(browser.image(:alt, 'circle')).to exist
+      expect(browser.image(:alt, /cir/)).to exist
+      expect(browser.image(:title, 'Circle')).to exist
     end
 
     it "returns the first image if given no args" do
-      browser.image.should exist
+      expect(browser.image).to exist
     end
 
     it "returns false when the image doesn't exist" do
-      browser.image(:id, 'no_such_id').should_not exist
-      browser.image(:id, /no_such_id/).should_not exist
-      browser.image(:src, 'no_such_src').should_not exist
-      browser.image(:src, /no_such_src/).should_not exist
-      browser.image(:alt, 'no_such_alt').should_not exist
-      browser.image(:alt, /no_such_alt/).should_not exist
-      browser.image(:title, 'no_such_title').should_not exist
-      browser.image(:title, /no_such_title/).should_not exist
+      expect(browser.image(:id, 'no_such_id')).to_not exist
+      expect(browser.image(:id, /no_such_id/)).to_not exist
+      expect(browser.image(:src, 'no_such_src')).to_not exist
+      expect(browser.image(:src, /no_such_src/)).to_not exist
+      expect(browser.image(:alt, 'no_such_alt')).to_not exist
+      expect(browser.image(:alt, /no_such_alt/)).to_not exist
+      expect(browser.image(:title, 'no_such_title')).to_not exist
+      expect(browser.image(:title, /no_such_title/)).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.image(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.image(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.image(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.image(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Attribute methods
   describe "#alt" do
     it "returns the alt attribute of the image if the image exists" do
-      browser.image(:id, 'square').alt.should == "square"
-      browser.image(:title, 'Circle').alt.should == 'circle'
+      expect(browser.image(:id, 'square').alt).to eq "square"
+      expect(browser.image(:title, 'Circle').alt).to eq 'circle'
     end
 
     it "returns an empty string if the image exists and the attribute doesn't" do
-      browser.image(:index, 0).alt.should == ""
+      expect(browser.image(:index, 0).alt).to eq ""
     end
 
     it "raises UnknownObjectException if the image doesn't exist" do
-      lambda { browser.image(:index, 1337).alt }.should raise_error(UnknownObjectException)
+      expect{ browser.image(:index, 1337).alt }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#id" do
     it "returns the id attribute of the image if the image exists" do
-      browser.image(:title, 'Square').id.should == 'square'
+      expect(browser.image(:title, 'Square').id).to eq 'square'
     end
 
     it "returns an empty string if the image exists and the attribute doesn't" do
-      browser.image(:index, 0).id.should == ""
+      expect(browser.image(:index, 0).id).to eq ""
     end
 
     it "raises UnknownObjectException if the image doesn't exist" do
-      lambda { browser.image(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{ browser.image(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#src" do
     it "returns the src attribute of the image if the image exists" do
-      browser.image(:id, 'square').src.should include("square.png")
+      expect(browser.image(:id, 'square').src).to include("square.png")
     end
 
     it "returns an empty string if the image exists and the attribute doesn't" do
-      browser.image(:index, 0).src.should == ""
+      expect(browser.image(:index, 0).src).to eq ""
     end
 
     it "raises UnknownObjectException if the image doesn't exist" do
-      lambda { browser.image(:index, 1337).src }.should raise_error(UnknownObjectException)
+      expect{ browser.image(:index, 1337).src }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#title" do
     it "returns the title attribute of the image if the image exists" do
-      browser.image(:id, 'square').title.should == 'Square'
+      expect(browser.image(:id, 'square').title).to eq 'Square'
     end
 
     it "returns an empty string if the image exists and the attribute doesn't" do
-      browser.image(:index, 0).title.should == ""
+      expect(browser.image(:index, 0).title).to eq ""
     end
 
     it "raises UnknownObjectException if the image doesn't exist" do
-      lambda { browser.image(:index, 1337).title }.should raise_error(UnknownObjectException)
+      expect{ browser.image(:index, 1337).title }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.image(:index, 0).should respond_to(:class_name)
-      browser.image(:index, 0).should respond_to(:id)
-      browser.image(:index, 0).should respond_to(:style)
-      browser.image(:index, 0).should respond_to(:text)
+      expect(browser.image(:index, 0)).to respond_to(:class_name)
+      expect(browser.image(:index, 0)).to respond_to(:id)
+      expect(browser.image(:index, 0)).to respond_to(:style)
+      expect(browser.image(:index, 0)).to respond_to(:text)
     end
   end
 
   # Manipulation methods
   describe "#click" do
     it "raises UnknownObjectException when the image doesn't exist" do
-      lambda { browser.image(:id,    'missing_attribute').click }.should raise_error(UnknownObjectException)
-      lambda { browser.image(:class, 'missing_attribute').click }.should raise_error(UnknownObjectException)
-      lambda { browser.image(:src,   'missing_attribute').click }.should raise_error(UnknownObjectException)
-      lambda { browser.image(:alt,   'missing_attribute').click }.should raise_error(UnknownObjectException)
+      expect{ browser.image(:id,    'missing_attribute').click }.to raise_error(UnknownObjectException)
+      expect{ browser.image(:class, 'missing_attribute').click }.to raise_error(UnknownObjectException)
+      expect{ browser.image(:src,   'missing_attribute').click }.to raise_error(UnknownObjectException)
+      expect{ browser.image(:alt,   'missing_attribute').click }.to raise_error(UnknownObjectException)
     end
   end
 
@@ -135,59 +135,59 @@ describe "Image" do
           browser.goto(WatirSpec.url_for("images.html", :needs_server => true))
           image = browser.image(:index, 1)
           path = "#{File.dirname(__FILE__)}/html#{image.src.gsub(WatirSpec.host, '')}"
-          image.file_created_date.to_i.should == File.mtime(path).to_i
+          image.file_created_date.to_i.to eq File.mtime(path).to_i
         end
       end
     end
 
     describe "#file_size" do
       it "returns the file size of the image if the image exists" do
-        browser.image(:id, 'square').file_size.should == File.size("#{WatirSpec.files}/images/square.png".sub("file://", ''))
+        expect(browser.image(:id, 'square').file_size).to eq File.size("#{WatirSpec.files}/images/square.png".sub("file://", ''))
       end
     end
   end
 
   it "raises UnknownObjectException if the image doesn't exist" do
-    lambda { browser.image(:index, 1337).file_size }.should raise_error(UnknownObjectException)
+    expect{ browser.image(:index, 1337).file_size }.to raise_error(UnknownObjectException)
   end
 
   describe "#height" do
     it "returns the height of the image if the image exists" do
-      browser.image(:id, 'square').height.should == 88
+      expect(browser.image(:id, 'square').height).to eq 88
     end
 
     it "raises UnknownObjectException if the image doesn't exist" do
-      lambda { browser.image(:index, 1337).height }.should raise_error(UnknownObjectException)
+      expect{ browser.image(:index, 1337).height }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#width" do
     it "returns the width of the image if the image exists" do
-      browser.image(:id, 'square').width.should == 88
+      expect(browser.image(:id, 'square').width).to eq 88
     end
 
     it "raises UnknownObjectException if the image doesn't exist" do
-      lambda { browser.image(:index, 1337).width }.should raise_error(UnknownObjectException)
+      expect{ browser.image(:index, 1337).width }.to raise_error(UnknownObjectException)
     end
   end
 
   # Other
   describe "#loaded?" do
     it "returns true if the image has been loaded" do
-      browser.image(:title, 'Circle').should be_loaded
-      browser.image(:alt, 'circle').should be_loaded
-      browser.image(:alt, /circle/).should be_loaded
+      expect(browser.image(:title, 'Circle')).to be_loaded
+      expect(browser.image(:alt, 'circle')).to be_loaded
+      expect(browser.image(:alt, /circle/)).to be_loaded
     end
 
     it "returns false if the image has not been loaded" do
-      browser.image(:id, 'no_such_file').should_not be_loaded
+      expect(browser.image(:id, 'no_such_file')).to_not be_loaded
     end
 
     it "raises UnknownObjectException if the image doesn't exist" do
-      lambda { browser.image(:id, 'no_such_image').loaded? }.should raise_error(UnknownObjectException)
-      lambda { browser.image(:src, 'no_such_image').loaded? }.should raise_error(UnknownObjectException)
-      lambda { browser.image(:alt, 'no_such_image').loaded? }.should raise_error(UnknownObjectException)
-      lambda { browser.image(:index, 1337).loaded? }.should raise_error(UnknownObjectException)
+      expect{ browser.image(:id, 'no_such_image').loaded? }.to raise_error(UnknownObjectException)
+      expect{ browser.image(:src, 'no_such_image').loaded? }.to raise_error(UnknownObjectException)
+      expect{ browser.image(:alt, 'no_such_image').loaded? }.to raise_error(UnknownObjectException)
+      expect{ browser.image(:index, 1337).loaded? }.to raise_error(UnknownObjectException)
     end
   end
 
@@ -197,7 +197,7 @@ describe "Image" do
         file = "#{File.expand_path Dir.pwd}/sample.img.dat"
         begin
           browser.image(:index, 1).save(file)
-          File.exist?(file).should be_true
+          expect(File.exist?(file)).to be_true
         ensure
           File.delete(file) if File.exist?(file)
         end

--- a/images_spec.rb
+++ b/images_spec.rb
@@ -10,20 +10,20 @@ describe "Images" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.images(:alt => "circle").to_a.should == [browser.image(:alt => "circle")]
+        expect(browser.images(:alt => "circle").to_a).to eq [browser.image(:alt => "circle")]
       end
     end
   end
 
   describe "#length" do
     it "returns the number of images" do
-      browser.images.length.should == 10
+      expect(browser.images.length).to eq 10
     end
   end
 
   describe "#[]" do
     it "returns the image at the given index" do
-      browser.images[5].id.should == "square"
+      expect(browser.images[5].id).to eq "square"
     end
   end
 
@@ -32,11 +32,11 @@ describe "Images" do
       count = 0
 
       browser.images.each_with_index do |c, index|
-        c.id.should == browser.image(:index, index).id
+        expect(c.id).to eq browser.image(:index, index).id
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/ins_spec.rb
+++ b/ins_spec.rb
@@ -10,120 +10,120 @@ describe "Ins" do
   # Exists method
   describe "#exist?" do
     it "returns true if the 'ins' exists" do
-      browser.ins(:id, "lead").should exist
-      browser.ins(:id, /lead/).should exist
-      browser.ins(:text, "This is an inserted text tag 1").should exist
-      browser.ins(:text, /This is an inserted text tag 1/).should exist
-      browser.ins(:class, "lead").should exist
-      browser.ins(:class, /lead/).should exist
-      browser.ins(:index, 0).should exist
-      browser.ins(:xpath, "//ins[@id='lead']").should exist
+      expect(browser.ins(:id, "lead")).to exist
+      expect(browser.ins(:id, /lead/)).to exist
+      expect(browser.ins(:text, "This is an inserted text tag 1")).to exist
+      expect(browser.ins(:text, /This is an inserted text tag 1/)).to exist
+      expect(browser.ins(:class, "lead")).to exist
+      expect(browser.ins(:class, /lead/)).to exist
+      expect(browser.ins(:index, 0)).to exist
+      expect(browser.ins(:xpath, "//ins[@id='lead']")).to exist
     end
 
     it "returns the first ins if given no args" do
-      browser.ins.should exist
+      expect(browser.ins).to exist
     end
 
     it "returns false if the element doesn't exist" do
-      browser.ins(:id, "no_such_id").should_not exist
-      browser.ins(:id, /no_such_id/).should_not exist
-      browser.ins(:text, "no_such_text").should_not exist
-      browser.ins(:text, /no_such_text/).should_not exist
-      browser.ins(:class, "no_such_class").should_not exist
-      browser.ins(:class, /no_such_class/).should_not exist
-      browser.ins(:index, 1337).should_not exist
-      browser.ins(:xpath, "//ins[@id='no_such_id']").should_not exist
+      expect(browser.ins(:id, "no_such_id")).to_not exist
+      expect(browser.ins(:id, /no_such_id/)).to_not exist
+      expect(browser.ins(:text, "no_such_text")).to_not exist
+      expect(browser.ins(:text, /no_such_text/)).to_not exist
+      expect(browser.ins(:class, "no_such_class")).to_not exist
+      expect(browser.ins(:class, /no_such_class/)).to_not exist
+      expect(browser.ins(:index, 1337)).to_not exist
+      expect(browser.ins(:xpath, "//ins[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.ins(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.ins(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.ins(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.ins(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Attribute methods
   describe "#class_name" do
     it "returns the class attribute" do
-      browser.ins(:index, 0).class_name.should == 'lead'
+      expect(browser.ins(:index, 0).class_name).to eq 'lead'
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.ins(:index, 2).class_name.should == ''
+      expect(browser.ins(:index, 2).class_name).to eq ''
     end
 
     it "raises UnknownObjectException if the ins doesn't exist" do
-      lambda { browser.ins(:id, 'no_such_id').class_name }.should raise_error(UnknownObjectException)
+      expect{ browser.ins(:id, 'no_such_id').class_name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#id" do
     it "returns the id attribute" do
-      browser.ins(:index, 0).id.should == "lead"
+      expect(browser.ins(:index, 0).id).to eq "lead"
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.ins(:index, 2).id.should == ''
+      expect(browser.ins(:index, 2).id).to eq ''
     end
 
     it "raises UnknownObjectException if the ins doesn't exist" do
-      lambda { browser.ins(:id, "no_such_id").id }.should raise_error(UnknownObjectException)
-      lambda { browser.ins(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{ browser.ins(:id, "no_such_id").id }.to raise_error(UnknownObjectException)
+      expect{ browser.ins(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#title" do
     it "returns the title attribute" do
-      browser.ins(:index, 0).title.should == 'Lorem ipsum'
+      expect(browser.ins(:index, 0).title).to eq 'Lorem ipsum'
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.ins(:index, 2).title.should == ''
+      expect(browser.ins(:index, 2).title).to eq ''
     end
 
     it "raises UnknownObjectException if the ins doesn't exist" do
-      lambda { browser.ins(:id, 'no_such_id').title }.should raise_error( UnknownObjectException)
-      lambda { browser.ins(:xpath, "//ins[@id='no_such_id']").title }.should raise_error( UnknownObjectException)
+      expect{ browser.ins(:id, 'no_such_id').title }.to raise_error( UnknownObjectException)
+      expect{ browser.ins(:xpath, "//ins[@id='no_such_id']").title }.to raise_error( UnknownObjectException)
     end
   end
 
   describe "#text" do
     it "returns the text of the ins" do
-      browser.ins(:index, 1).text.should == 'This is an inserted text tag 2'
+      expect(browser.ins(:index, 1).text).to eq 'This is an inserted text tag 2'
     end
 
     it "returns an empty string if the element doesn't contain any text" do
-      browser.ins(:index, 3).text.should == ''
+      expect(browser.ins(:index, 3).text).to eq ''
     end
 
     it "raises UnknownObjectException if the ins doesn't exist" do
-      lambda { browser.ins(:id, 'no_such_id').text }.should raise_error( UnknownObjectException)
-      lambda { browser.ins(:xpath , "//ins[@id='no_such_id']").text }.should raise_error( UnknownObjectException)
+      expect{ browser.ins(:id, 'no_such_id').text }.to raise_error( UnknownObjectException)
+      expect{ browser.ins(:xpath , "//ins[@id='no_such_id']").text }.to raise_error( UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.ins(:index, 0).should respond_to(:class_name)
-      browser.ins(:index, 0).should respond_to(:id)
-      browser.ins(:index, 0).should respond_to(:title)
-      browser.ins(:index, 0).should respond_to(:text)
+      expect(browser.ins(:index, 0)).to respond_to(:class_name)
+      expect(browser.ins(:index, 0)).to respond_to(:id)
+      expect(browser.ins(:index, 0)).to respond_to(:title)
+      expect(browser.ins(:index, 0)).to respond_to(:text)
     end
   end
 
   # Other
   describe "#click" do
     it "fires events" do
-      browser.ins(:class, 'footer').text.should_not include('Javascript')
+      expect(browser.ins(:class, 'footer').text).to_not include('Javascript')
       browser.ins(:class, 'footer').click
-      browser.ins(:class, 'footer').text.should include('Javascript')
+      expect(browser.ins(:class, 'footer').text).to include('Javascript')
     end
 
     it "raises UnknownObjectException if the ins doesn't exist" do
-      lambda { browser.ins(:id, "no_such_id").click }.should raise_error(UnknownObjectException)
-      lambda { browser.ins(:title, "no_such_title").click }.should raise_error(UnknownObjectException)
+      expect{ browser.ins(:id, "no_such_id").click }.to raise_error(UnknownObjectException)
+      expect{ browser.ins(:title, "no_such_title").click }.to raise_error(UnknownObjectException)
     end
   end
 

--- a/inses_spec.rb
+++ b/inses_spec.rb
@@ -10,20 +10,20 @@ describe "Inses" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.inses(:class => "lead").to_a.should == [browser.ins(:class => "lead")]
+        expect(browser.inses(:class => "lead").to_a).to eq [browser.ins(:class => "lead")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the number of inses" do
-      browser.inses.length.should == 5
+      expect(browser.inses.length).to eq 5
     end
   end
 
   describe "#[]" do
     it "returns the ins at the given index" do
-      browser.inses[0].id.should == "lead"
+      expect(browser.inses[0].id).to eq "lead"
     end
   end
 
@@ -32,11 +32,11 @@ describe "Inses" do
       count = 0
 
       browser.inses.each_with_index do |s, index|
-        s.id.should == browser.ins(:index, index).id
+        expect(s.id).to eq browser.ins(:index, index).id
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/label_spec.rb
+++ b/label_spec.rb
@@ -10,70 +10,70 @@ describe "Label" do
   # Exists method
   describe "#exists?" do
     it "returns true if the element exists" do
-      browser.label(:id, 'first_label').should exist
-      browser.label(:id, /first_label/).should exist
-      browser.label(:for, "new_user_first_name").should exist
-      browser.label(:for, /new_user_first_name/).should exist
-      browser.label(:text, 'First name').should exist
-      browser.label(:text, /First name/).should exist
-      browser.label(:index, 0).should exist
-      browser.label(:xpath, "//label[@id='first_label']").should exist
+      expect(browser.label(:id, 'first_label')).to exist
+      expect(browser.label(:id, /first_label/)).to exist
+      expect(browser.label(:for, "new_user_first_name")).to exist
+      expect(browser.label(:for, /new_user_first_name/)).to exist
+      expect(browser.label(:text, 'First name')).to exist
+      expect(browser.label(:text, /First name/)).to exist
+      expect(browser.label(:index, 0)).to exist
+      expect(browser.label(:xpath, "//label[@id='first_label']")).to exist
     end
 
     it "returns the first label if given no args" do
-      browser.label.should exist
+      expect(browser.label).to exist
     end
 
     it "returns false if the element does not exist" do
-      browser.label(:id, 'no_such_id').should_not exist
-      browser.label(:id, /no_such_id/).should_not exist
-      browser.label(:text, 'no_such_text').should_not exist
-      browser.label(:text, /no_such_text/).should_not exist
-      browser.label(:index, 1337).should_not exist
-      browser.label(:xpath, "//input[@id='no_such_id']").should_not exist
+      expect(browser.label(:id, 'no_such_id')).to_not exist
+      expect(browser.label(:id, /no_such_id/)).to_not exist
+      expect(browser.label(:text, 'no_such_text')).to_not exist
+      expect(browser.label(:text, /no_such_text/)).to_not exist
+      expect(browser.label(:index, 1337)).to_not exist
+      expect(browser.label(:xpath, "//input[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.label(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.label(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.label(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.label(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   describe "click" do
     it "fires the onclick event" do
       browser.label(:id, 'first_label').click
-      messages.first.should == 'label'
+      expect(messages.first).to eq 'label'
     end
   end
 
   # Attribute methods
   describe "#id" do
     it "returns the id attribute if the label exists" do
-      browser.label(:index, 0).id.should == "first_label"
+      expect(browser.label(:index, 0).id).to eq "first_label"
     end
 
     it "raises UnknownObjectException if the label doesn't exist" do
-      lambda { browser.label(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{ browser.label(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#for" do
     it "returns the 'for' attribute if the label exists" do
-      browser.label(:index, 0).for.should == "new_user_first_name"
+      expect(browser.label(:index, 0).for).to eq "new_user_first_name"
     end
 
     it "raises UnknownObjectException if the label doesn't exist" do
-      lambda { browser.label(:index, 1337).for }.should raise_error(UnknownObjectException)
+      expect{ browser.label(:index, 1337).for }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.label(:index, 0).should respond_to(:id)
-      browser.label(:index, 0).should respond_to(:for)
+      expect(browser.label(:index, 0)).to respond_to(:id)
+      expect(browser.label(:index, 0)).to respond_to(:for)
     end
   end
 

--- a/labels_spec.rb
+++ b/labels_spec.rb
@@ -10,20 +10,20 @@ describe "Labels" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.labels(:for => "new_user_first_name").to_a.should == [browser.label(:for => "new_user_first_name")]
+        expect(browser.labels(:for => "new_user_first_name").to_a).to eq [browser.label(:for => "new_user_first_name")]
       end
     end
   end
 
   describe "#length" do
     it "returns the number of labels" do
-      browser.labels.length.should == 32
+      expect(browser.labels.length).to eq 32
     end
   end
 
   describe "#[]" do
     it "returns the label at the given index" do
-      browser.labels[0].id.should == "first_label"
+      expect(browser.labels[0].id).to eq "first_label"
     end
   end
 
@@ -32,11 +32,11 @@ describe "Labels" do
       count = 0
 
       browser.labels.each_with_index do |l, index|
-        l.id.should == browser.label(:index, index).id
+        expect(l.id).to eq browser.label(:index, index).id
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/li_spec.rb
+++ b/li_spec.rb
@@ -10,106 +10,106 @@ describe "Li" do
   # Exists method
   describe "#exist?" do
     it "returns true if the 'li' exists" do
-      browser.li(:id, "non_link_1").should exist
-      browser.li(:id, /non_link_1/).should exist
-      browser.li(:text, "Non-link 3").should exist
-      browser.li(:text, /Non-link 3/).should exist
-      browser.li(:class, "nonlink").should exist
-      browser.li(:class, /nonlink/).should exist
-      browser.li(:index, 0).should exist
-      browser.li(:xpath, "//li[@id='non_link_1']").should exist
+      expect(browser.li(:id, "non_link_1")).to exist
+      expect(browser.li(:id, /non_link_1/)).to exist
+      expect(browser.li(:text, "Non-link 3")).to exist
+      expect(browser.li(:text, /Non-link 3/)).to exist
+      expect(browser.li(:class, "nonlink")).to exist
+      expect(browser.li(:class, /nonlink/)).to exist
+      expect(browser.li(:index, 0)).to exist
+      expect(browser.li(:xpath, "//li[@id='non_link_1']")).to exist
     end
 
     it "returns the first element if given no args" do
-      browser.li.should exist
+      expect(browser.li).to exist
     end
 
     it "returns false if the 'li' doesn't exist" do
-      browser.li(:id, "no_such_id").should_not exist
-      browser.li(:id, /no_such_id/).should_not exist
-      browser.li(:text, "no_such_text").should_not exist
-      browser.li(:text, /no_such_text/).should_not exist
-      browser.li(:class, "no_such_class").should_not exist
-      browser.li(:class, /no_such_class/).should_not exist
-      browser.li(:index, 1337).should_not exist
-      browser.li(:xpath, "//li[@id='no_such_id']").should_not exist
+      expect(browser.li(:id, "no_such_id")).to_not exist
+      expect(browser.li(:id, /no_such_id/)).to_not exist
+      expect(browser.li(:text, "no_such_text")).to_not exist
+      expect(browser.li(:text, /no_such_text/)).to_not exist
+      expect(browser.li(:class, "no_such_class")).to_not exist
+      expect(browser.li(:class, /no_such_class/)).to_not exist
+      expect(browser.li(:index, 1337)).to_not exist
+      expect(browser.li(:xpath, "//li[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.li(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.li(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.li(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.li(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Attribute methods
   describe "#class_name" do
     it "returns the class attribute" do
-      browser.li(:id, 'non_link_1').class_name.should == 'nonlink'
+      expect(browser.li(:id, 'non_link_1').class_name).to eq 'nonlink'
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.li(:index, 0).class_name.should == ''
+      expect(browser.li(:index, 0).class_name).to eq ''
     end
 
     it "raises UnknownObjectException if the li doesn't exist" do
-      lambda { browser.li(:id, 'no_such_id').class_name }.should raise_error(UnknownObjectException)
+      expect{ browser.li(:id, 'no_such_id').class_name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#id" do
     it "returns the id attribute" do
-      browser.li(:class, 'nonlink').id.should == "non_link_1"
+      expect(browser.li(:class, 'nonlink').id).to eq "non_link_1"
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.li(:index, 0).id.should == ''
+      expect(browser.li(:index, 0).id).to eq ''
     end
 
     it "raises UnknownObjectException if the li doesn't exist" do
-      lambda { browser.li(:id, "no_such_id").id }.should raise_error(UnknownObjectException)
-      lambda { browser.li(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{ browser.li(:id, "no_such_id").id }.to raise_error(UnknownObjectException)
+      expect{ browser.li(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#title" do
     it "returns the title attribute" do
-      browser.li(:id, 'non_link_1').title.should == 'This is not a link!'
+      expect(browser.li(:id, 'non_link_1').title).to eq 'This is not a link!'
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.li(:index, 0).title.should == ''
+      expect(browser.li(:index, 0).title).to eq ''
     end
 
     it "raises UnknownObjectException if the li doesn't exist" do
-      lambda { browser.li(:id, 'no_such_id').title }.should raise_error( UnknownObjectException)
-      lambda { browser.li(:xpath, "//li[@id='no_such_id']").title }.should raise_error( UnknownObjectException)
+      expect{ browser.li(:id, 'no_such_id').title }.to raise_error( UnknownObjectException)
+      expect{ browser.li(:xpath, "//li[@id='no_such_id']").title }.to raise_error( UnknownObjectException)
     end
   end
 
   describe "#text" do
     it "returns the text of the li" do
-      browser.li(:id, 'non_link_1').text.should == 'Non-link 1'
+      expect(browser.li(:id, 'non_link_1').text).to eq 'Non-link 1'
     end
 
     it "returns an empty string if the element doesn't contain any text" do
-      browser.li(:index, 0).text.should == ''
+      expect(browser.li(:index, 0).text).to eq ''
     end
 
     it "raises UnknownObjectException if the li doesn't exist" do
-      lambda { browser.li(:id, 'no_such_id').text }.should raise_error( UnknownObjectException)
-      lambda { browser.li(:xpath , "//li[@id='no_such_id']").text }.should raise_error( UnknownObjectException)
+      expect{ browser.li(:id, 'no_such_id').text }.to raise_error( UnknownObjectException)
+      expect{ browser.li(:xpath , "//li[@id='no_such_id']").text }.to raise_error( UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.li(:index, 0).should respond_to(:class_name)
-      browser.li(:index, 0).should respond_to(:id)
-      browser.li(:index, 0).should respond_to(:text)
-      browser.li(:index, 0).should respond_to(:title)
+      expect(browser.li(:index, 0)).to respond_to(:class_name)
+      expect(browser.li(:index, 0)).to respond_to(:id)
+      expect(browser.li(:index, 0)).to respond_to(:text)
+      expect(browser.li(:index, 0)).to respond_to(:title)
     end
   end
 

--- a/link_spec.rb
+++ b/link_spec.rb
@@ -10,135 +10,135 @@ describe "Link" do
   # Exists method
   describe "#exist?" do
     it "returns true if the link exists" do
-      browser.link(:id, 'link_2').should exist
-      browser.link(:id, /link_2/).should exist
-      browser.link(:title, "link_title_2").should exist
-      browser.link(:title, /link_title_2/).should exist
-      browser.link(:text, "Link 2").should exist
-      browser.link(:text, /Link 2/i).should exist
+      expect(browser.link(:id, 'link_2')).to exist
+      expect(browser.link(:id, /link_2/)).to exist
+      expect(browser.link(:title, "link_title_2")).to exist
+      expect(browser.link(:title, /link_title_2/)).to exist
+      expect(browser.link(:text, "Link 2")).to exist
+      expect(browser.link(:text, /Link 2/i)).to exist
       not_compliant_on :internet_explorer do
-        browser.link(:href, 'non_control_elements.html').should exist
+        expect(browser.link(:href, 'non_control_elements.html')).to exist
       end
-      browser.link(:href, /non_control_elements.html/).should exist
-      browser.link(:index, 1).should exist
-      browser.link(:xpath, "//a[@id='link_2']").should exist
+      expect(browser.link(:href, /non_control_elements.html/)).to exist
+      expect(browser.link(:index, 1)).to exist
+      expect(browser.link(:xpath, "//a[@id='link_2']")).to exist
     end
 
     it "returns the first link if given no args" do
-      browser.link.should exist
+      expect(browser.link).to exist
     end
 
     it "strips spaces from href attribute when locating elements" do
-      browser.link(:href, /strip_space$/).should exist
+      expect(browser.link(:href, /strip_space$/)).to exist
     end
 
     it "returns false if the link doesn't exist" do
-      browser.link(:id, 'no_such_id').should_not exist
-      browser.link(:id, /no_such_id/).should_not exist
-      browser.link(:title, "no_such_title").should_not exist
-      browser.link(:title, /no_such_title/).should_not exist
-      browser.link(:text, "no_such_text").should_not exist
-      browser.link(:text, /no_such_text/i).should_not exist
-      browser.link(:href, 'no_such_href').should_not exist
-      browser.link(:href, /no_such_href/).should_not exist
-      browser.link(:index, 1337).should_not exist
-      browser.link(:xpath, "//a[@id='no_such_id']").should_not exist
+      expect(browser.link(:id, 'no_such_id')).to_not exist
+      expect(browser.link(:id, /no_such_id/)).to_not exist
+      expect(browser.link(:title, "no_such_title")).to_not exist
+      expect(browser.link(:title, /no_such_title/)).to_not exist
+      expect(browser.link(:text, "no_such_text")).to_not exist
+      expect(browser.link(:text, /no_such_text/i)).to_not exist
+      expect(browser.link(:href, 'no_such_href')).to_not exist
+      expect(browser.link(:href, /no_such_href/)).to_not exist
+      expect(browser.link(:index, 1337)).to_not exist
+      expect(browser.link(:xpath, "//a[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.link(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.link(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.link(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.link(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Attribute methods
   describe "#class_name" do
     it "returns the type attribute if the link exists" do
-      browser.link(:index, 1).class_name.should == "external"
+      expect(browser.link(:index, 1).class_name).to eq "external"
     end
 
     it "returns an empty string if the link exists and the attribute doesn't" do
-      browser.link(:index, 0).class_name.should == ''
+      expect(browser.link(:index, 0).class_name).to eq ''
     end
 
     it "raises an UnknownObjectException if the link doesn't exist" do
-      lambda { browser.link(:index, 1337).class_name }.should raise_error(UnknownObjectException)
+      expect{ browser.link(:index, 1337).class_name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#href" do
     it "returns the href attribute if the link exists" do
-      browser.link(:index, 1).href.should =~ /non_control_elements/
+      expect(browser.link(:index, 1).href).to match(/non_control_elements/)
     end
 
     it "returns an empty string if the link exists and the attribute doesn't" do
-      browser.link(:index, 0).href.should == ""
+      expect(browser.link(:index, 0).href).to eq ""
     end
 
     it "raises an UnknownObjectException if the link doesn't exist" do
-      lambda { browser.link(:index, 1337).href }.should raise_error(UnknownObjectException)
+      expect{ browser.link(:index, 1337).href }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#href" do
     it "returns the href attribute" do
-      browser.link(:index, 1).href.should =~ /non_control_elements/
+      expect(browser.link(:index, 1).href).to match(/non_control_elements/)
     end
   end
 
   describe "#id" do
     it "returns the id attribute if the link exists" do
-      browser.link(:index, 1).id.should == "link_2"
+      expect(browser.link(:index, 1).id).to eq "link_2"
     end
 
     it "returns an empty string if the link exists and the attribute doesn't" do
-      browser.link(:index, 0).id.should == ""
+      expect(browser.link(:index, 0).id).to eq ""
     end
 
     it "raises an UnknownObjectException if the link doesn't exist" do
-      lambda { browser.link(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{ browser.link(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#text" do
     it "returns the link text" do
-      browser.link(:index, 1).text.should == "Link 2"
+      expect(browser.link(:index, 1).text).to eq "Link 2"
     end
 
     it "returns an empty string if the link exists and contains no text" do
-      browser.link(:index, 0).text.should == ""
+      expect(browser.link(:index, 0).text).to eq ""
     end
 
     it "raises an UnknownObjectException if the link doesn't exist" do
-      lambda { browser.link(:index, 1337).text }.should raise_error(UnknownObjectException)
+      expect{ browser.link(:index, 1337).text }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#title" do
     it "returns the type attribute if the link exists" do
-      browser.link(:index, 1).title.should == "link_title_2"
+      expect(browser.link(:index, 1).title).to eq "link_title_2"
     end
 
     it "returns an empty string if the link exists and the attribute doesn't" do
-      browser.link(:index, 0).title.should == ""
+      expect(browser.link(:index, 0).title).to eq ""
     end
 
     it "raises an UnknownObjectException if the link doesn't exist" do
-      lambda { browser.link(:index, 1337).title }.should raise_error(UnknownObjectException)
+      expect{ browser.link(:index, 1337).title }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.link(:index, 0).should respond_to(:class_name)
-      browser.link(:index, 0).should respond_to(:href)
-      browser.link(:index, 0).should respond_to(:id)
-      browser.link(:index, 0).should respond_to(:style)
-      browser.link(:index, 0).should respond_to(:text)
-      browser.link(:index, 0).should respond_to(:title)
+      expect(browser.link(:index, 0)).to respond_to(:class_name)
+      expect(browser.link(:index, 0)).to respond_to(:href)
+      expect(browser.link(:index, 0)).to respond_to(:id)
+      expect(browser.link(:index, 0)).to respond_to(:style)
+      expect(browser.link(:index, 0)).to respond_to(:text)
+      expect(browser.link(:index, 0)).to respond_to(:title)
     end
   end
 
@@ -146,27 +146,27 @@ describe "Link" do
   describe "#click" do
     it "finds an existing link by (:text, String) and clicks it" do
       browser.link(:text, "Link 3").click
-      browser.text.include?("User administration").should be_true
+      expect(browser.text.include?("User administration")).to be_true
     end
 
     it "finds an existing link by (:text, Regexp) and clicks it" do
       browser.link(:href, /forms_with_input_elements/).click
-      browser.text.include?("User administration").should be_true
+      expect(browser.text.include?("User administration")).to be_true
     end
 
     it "finds an existing link by (:index, Integer) and clicks it" do
       browser.link(:index, 2).click
-      browser.text.include?("User administration").should be_true
+      expect(browser.text.include?("User administration")).to be_true
     end
 
     it "raises an UnknownObjectException if the link doesn't exist" do
-      lambda { browser.link(:index, 1337).click }.should raise_error(UnknownObjectException)
+      expect{ browser.link(:index, 1337).click }.to raise_error(UnknownObjectException)
     end
 
     it "clicks a link with no text content but an img child" do
       browser.goto WatirSpec.url_for("images.html")
       browser.link(:href => /definition_lists.html/).click
-      browser.title.should == 'definition_lists'
+      expect(browser.title).to eq 'definition_lists'
     end
 
   end

--- a/links_spec.rb
+++ b/links_spec.rb
@@ -10,24 +10,24 @@ describe "Links" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.links(:title => "link_title_2").to_a.should == [browser.link(:title => "link_title_2")]
+        expect(browser.links(:title => "link_title_2").to_a).to eq [browser.link(:title => "link_title_2")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the number of links" do
-      browser.links.length.should == 4
+      expect(browser.links.length).to eq 4
     end
   end
 
   describe "#[]" do
     it "returns the link at the given index" do
-      browser.links[2].id.should == "link_3"
+      expect(browser.links[2].id).to eq "link_3"
     end
 
     it "returns a Link object also when the index is out of bounds" do
-      browser.links[2000].should_not be_nil
+      expect(browser.links[2000]).to_not be_nil
     end
   end
 
@@ -36,11 +36,11 @@ describe "Links" do
       count = 0
 
       browser.links.each_with_index do |c, index|
-        c.id.should == browser.link(:index, index).id
+        expect(c.id).to eq browser.link(:index, index).id
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/lis_spec.rb
+++ b/lis_spec.rb
@@ -10,20 +10,20 @@ describe "Lis" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.lis(:class => "nonlink").to_a.should == [browser.li(:class => "nonlink")]
+        expect(browser.lis(:class => "nonlink").to_a).to eq [browser.li(:class => "nonlink")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the number of lis" do
-      browser.lis.length.should == 18
+      expect(browser.lis.length).to eq 18
     end
   end
 
   describe "#[]" do
     it "returns the li at the given index" do
-      browser.lis[4].id.should == "non_link_1"
+      expect(browser.lis[4].id).to eq "non_link_1"
     end
   end
 
@@ -32,13 +32,13 @@ describe "Lis" do
       count = 0
 
       browser.lis.each_with_index do |l, index|
-        l.id.should == browser.li(:index, index).id
-        l.value.should == browser.li(:index, index).value
+        expect(l.id).to eq browser.li(:index, index).id
+        expect(l.value).to eq browser.li(:index, index).value
 
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/map_spec.rb
+++ b/map_spec.rb
@@ -10,71 +10,71 @@ describe "Map" do
   # Exists method
   describe "#exist?" do
     it "returns true if the 'map' exists" do
-      browser.map(:id, "triangle_map").should exist
-      browser.map(:id, /triangle_map/).should exist
-      browser.map(:name, "triangle_map").should exist
-      browser.map(:name, /triangle_map/).should exist
-      browser.map(:index, 0).should exist
-      browser.map(:xpath, "//map[@id='triangle_map']").should exist
+      expect(browser.map(:id, "triangle_map")).to exist
+      expect(browser.map(:id, /triangle_map/)).to exist
+      expect(browser.map(:name, "triangle_map")).to exist
+      expect(browser.map(:name, /triangle_map/)).to exist
+      expect(browser.map(:index, 0)).to exist
+      expect(browser.map(:xpath, "//map[@id='triangle_map']")).to exist
     end
 
     it "returns the first map if given no args" do
-      browser.map.should exist
+      expect(browser.map).to exist
     end
 
     it "returns false if the 'map' doesn't exist" do
-      browser.map(:id, "no_such_id").should_not exist
-      browser.map(:id, /no_such_id/).should_not exist
-      browser.map(:name, "no_such_id").should_not exist
-      browser.map(:name, /no_such_id/).should_not exist
-      browser.map(:index, 1337).should_not exist
-      browser.map(:xpath, "//map[@id='no_such_id']").should_not exist
+      expect(browser.map(:id, "no_such_id")).to_not exist
+      expect(browser.map(:id, /no_such_id/)).to_not exist
+      expect(browser.map(:name, "no_such_id")).to_not exist
+      expect(browser.map(:name, /no_such_id/)).to_not exist
+      expect(browser.map(:index, 1337)).to_not exist
+      expect(browser.map(:xpath, "//map[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.map(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.map(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.map(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.map(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Attribute methods
   describe "#id" do
     it "returns the id attribute" do
-      browser.map(:index, 0).id.should == "triangle_map"
+      expect(browser.map(:index, 0).id).to eq "triangle_map"
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.map(:index, 1).id.should == ''
+      expect(browser.map(:index, 1).id).to eq ''
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      lambda { browser.map(:id, "no_such_id").id }.should raise_error(UnknownObjectException)
-      lambda { browser.map(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{ browser.map(:id, "no_such_id").id }.to raise_error(UnknownObjectException)
+      expect{ browser.map(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#name" do
     it "returns the name attribute" do
-      browser.map(:index, 0).name.should == "triangle_map"
+      expect(browser.map(:index, 0).name).to eq "triangle_map"
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.map(:index, 1).name.should == ''
+      expect(browser.map(:index, 1).name).to eq ''
     end
 
     it "raises UnknownObjectException if the map doesn't exist" do
-      lambda { browser.map(:id, "no_such_id").name }.should raise_error(UnknownObjectException)
-      lambda { browser.map(:index, 1337).name }.should raise_error(UnknownObjectException)
+      expect{ browser.map(:id, "no_such_id").name }.to raise_error(UnknownObjectException)
+      expect{ browser.map(:index, 1337).name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.map(:index, 0).should respond_to(:id)
-      browser.map(:index, 0).should respond_to(:name)
+      expect(browser.map(:index, 0)).to respond_to(:id)
+      expect(browser.map(:index, 0)).to respond_to(:name)
     end
   end
 end

--- a/maps_spec.rb
+++ b/maps_spec.rb
@@ -10,20 +10,20 @@ describe "Maps" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.maps(:name => "triangle_map").to_a.should == [browser.map(:name => "triangle_map")]
+        expect(browser.maps(:name => "triangle_map").to_a).to eq [browser.map(:name => "triangle_map")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the number of maps" do
-      browser.maps.length.should == 2
+      expect(browser.maps.length).to eq 2
     end
   end
 
   describe "#[]" do
     it "returns the p at the given index" do
-      browser.maps[0].id.should == "triangle_map"
+      expect(browser.maps[0].id).to eq "triangle_map"
     end
   end
 
@@ -32,12 +32,12 @@ describe "Maps" do
       count = 0
 
       browser.maps.each_with_index do |m, index|
-        m.name.should == browser.map(:index, index).name
-        m.id.should == browser.map(:index, index).id
+        expect(m.name).to eq browser.map(:index, index).name
+        expect(m.id).to eq browser.map(:index, index).id
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/meta_spec.rb
+++ b/meta_spec.rb
@@ -8,17 +8,17 @@ describe "Meta" do
 
   describe "#exist?" do
     it "returns true if the meta tag exists" do
-      browser.meta(:http_equiv, "Content-Type").should exist
+      expect(browser.meta(:http_equiv, "Content-Type")).to exist
     end
 
     it "returns the first meta if given no args" do
-      browser.meta.should exist
+      expect(browser.meta).to exist
     end
   end
 
   describe "content" do
     it "returns the content attribute of the tag" do
-      browser.meta(:http_equiv, "Content-Type").content.should == "text/html; charset=utf-8"
+      expect(browser.meta(:http_equiv, "Content-Type").content).to eq "text/html; charset=utf-8"
     end
   end
 end

--- a/metas_spec.rb
+++ b/metas_spec.rb
@@ -10,20 +10,20 @@ describe "Metas" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.metas(:name => "description").to_a.should == [browser.meta(:name => "description")]
+        expect(browser.metas(:name => "description").to_a).to eq [browser.meta(:name => "description")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the number of meta elements" do
-      browser.metas.length.should == 2
+      expect(browser.metas.length).to eq 2
     end
   end
 
   describe "#[]" do
     it "returns the meta element at the given index" do
-      browser.metas[1].name.should == "description"
+      expect(browser.metas[1].name).to eq "description"
     end
   end
 
@@ -32,11 +32,11 @@ describe "Metas" do
       count = 0
 
       browser.metas.each_with_index do |m, index|
-        m.content.should == browser.meta(:index, index).content
+        expect(m.content).to eq browser.meta(:index, index).content
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/modal_dialog_spec.rb
+++ b/modal_dialog_spec.rb
@@ -18,24 +18,24 @@ describe "Modal Dialog" do
 
     describe "#exists?" do
       it "returns true if modal dialog exists" do
-        @modal.should exist
+        expect(@modal).to exist
       end
 
       it "returns false if modal dialog doesn't exist" do
         @modal.close
-        @modal.should_not exist
+        expect(@modal).to_not exist
       end
     end
 
     it "#title" do
-      @modal.title.should == 'Forms with input elements'
+      expect(@modal.title).to eq 'Forms with input elements'
     end
 
     it "allows to access elements within" do
-      @modal.select_list(:id, 'new_user_country').should exist
-      @modal.text_field(:id, 'new_user_email').should exist
-      @modal.radio(:id, 'new_user_newsletter_no').should exist
-      @modal.checkbox(:id, 'new_user_interests_cars').should exist
+      expect(@modal.select_list(:id, 'new_user_country')).to exist
+      expect(@modal.text_field(:id, 'new_user_email')).to exist
+      expect(@modal.radio(:id, 'new_user_newsletter_no')).to exist
+      expect(@modal.checkbox(:id, 'new_user_interests_cars')).to exist
     end
   end
 

--- a/ol_spec.rb
+++ b/ol_spec.rb
@@ -10,81 +10,81 @@ describe "Ol" do
     # Exists method
     describe "#exist?" do
       it "returns true if the 'ol' exists" do
-        browser.ol(:id, "favorite_compounds").should exist
-        browser.ol(:id, /favorite_compounds/).should exist
-        browser.ol(:index, 0).should exist
-        browser.ol(:xpath, "//ol[@id='favorite_compounds']").should exist
+        expect(browser.ol(:id, "favorite_compounds")).to exist
+        expect(browser.ol(:id, /favorite_compounds/)).to exist
+        expect(browser.ol(:index, 0)).to exist
+        expect(browser.ol(:xpath, "//ol[@id='favorite_compounds']")).to exist
       end
 
       it "returns the first ol if given no args" do
-        browser.ol.should exist
+        expect(browser.ol).to exist
       end
 
       it "returns false if the 'ol' doesn't exist" do
-        browser.ol(:id, "no_such_id").should_not exist
-        browser.ol(:id, /no_such_id/).should_not exist
-        browser.ol(:text, "no_such_text").should_not exist
-        browser.ol(:text, /no_such_text/).should_not exist
-        browser.ol(:class, "no_such_class").should_not exist
-        browser.ol(:class, /no_such_class/).should_not exist
-        browser.ol(:index, 1337).should_not exist
-        browser.ol(:xpath, "//ol[@id='no_such_id']").should_not exist
+        expect(browser.ol(:id, "no_such_id")).to_not exist
+        expect(browser.ol(:id, /no_such_id/)).to_not exist
+        expect(browser.ol(:text, "no_such_text")).to_not exist
+        expect(browser.ol(:text, /no_such_text/)).to_not exist
+        expect(browser.ol(:class, "no_such_class")).to_not exist
+        expect(browser.ol(:class, /no_such_class/)).to_not exist
+        expect(browser.ol(:index, 1337)).to_not exist
+        expect(browser.ol(:xpath, "//ol[@id='no_such_id']")).to_not exist
       end
 
     it "returns false if the 'ol' doesn't exist" do
-      browser.ol(:id, "no_such_id").should_not exist
-      browser.ol(:id, /no_such_id/).should_not exist
-      browser.ol(:text, "no_such_text").should_not exist
-      browser.ol(:text, /no_such_text/).should_not exist
-      browser.ol(:class, "no_such_class").should_not exist
-      browser.ol(:class, /no_such_class/).should_not exist
-      browser.ol(:index, 1337).should_not exist
-      browser.ol(:xpath, "//ol[@id='no_such_id']").should_not exist
+      expect(browser.ol(:id, "no_such_id")).to_not exist
+      expect(browser.ol(:id, /no_such_id/)).to_not exist
+      expect(browser.ol(:text, "no_such_text")).to_not exist
+      expect(browser.ol(:text, /no_such_text/)).to_not exist
+      expect(browser.ol(:class, "no_such_class")).to_not exist
+      expect(browser.ol(:class, /no_such_class/)).to_not exist
+      expect(browser.ol(:index, 1337)).to_not exist
+      expect(browser.ol(:xpath, "//ol[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.ol(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.ol(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.ol(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.ol(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Attribute methods
   describe "#class_name" do
     it "returns the class attribute" do
-      browser.ol(:id, 'favorite_compounds').class_name.should == 'chemistry'
+      expect(browser.ol(:id, 'favorite_compounds').class_name).to eq 'chemistry'
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.ol(:index, 1).class_name.should == ''
+      expect(browser.ol(:index, 1).class_name).to eq ''
     end
 
     it "raises UnknownObjectException if the ol doesn't exist" do
-      lambda { browser.ol(:id, 'no_such_id').class_name }.should raise_error(UnknownObjectException)
+      expect{ browser.ol(:id, 'no_such_id').class_name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#id" do
     it "returns the id attribute" do
-      browser.ol(:class, 'chemistry').id.should == "favorite_compounds"
+      expect(browser.ol(:class, 'chemistry').id).to eq "favorite_compounds"
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.ol(:index, 1).id.should == ''
+      expect(browser.ol(:index, 1).id).to eq ''
     end
 
     it "raises UnknownObjectException if the ol doesn't exist" do
-      lambda { browser.ol(:id, "no_such_id").id }.should raise_error(UnknownObjectException)
-      lambda { browser.ol(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{ browser.ol(:id, "no_such_id").id }.to raise_error(UnknownObjectException)
+      expect{ browser.ol(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.ol(:index, 0).should respond_to(:class_name)
-      browser.ol(:index, 0).should respond_to(:id)
+      expect(browser.ol(:index, 0)).to respond_to(:class_name)
+      expect(browser.ol(:index, 0)).to respond_to(:id)
     end
   end
 end

--- a/ols_spec.rb
+++ b/ols_spec.rb
@@ -10,20 +10,20 @@ describe "Ols" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.ols(:class => "chemistry").to_a.should == [browser.ol(:class => "chemistry")]
+        expect(browser.ols(:class => "chemistry").to_a).to eq [browser.ol(:class => "chemistry")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the number of ols" do
-      browser.ols.length.should == 2
+      expect(browser.ols.length).to eq 2
     end
   end
 
   describe "#[]" do
     it "returns the ol at the given index" do
-      browser.ols[0].id.should == "favorite_compounds"
+      expect(browser.ols[0].id).to eq "favorite_compounds"
     end
   end
 
@@ -32,11 +32,11 @@ describe "Ols" do
       count = 0
 
       browser.ols.each_with_index do |ol, index|
-        ol.id.should == browser.ol(:index, index).id
+        expect(ol.id).to eq browser.ol(:index, index).id
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/option_spec.rb
+++ b/option_spec.rb
@@ -9,88 +9,88 @@ describe "Option" do
 
   describe "#exists?" do
     it "returns true if the element exists (page context)" do
-      browser.option(:id, "nor").should exist
-      browser.option(:id, /nor/).should exist
-      browser.option(:value, "2").should exist
-      browser.option(:value, /2/).should exist
-      browser.option(:text, "Norway").should exist
-      browser.option(:text, /Norway/).should exist
-      browser.option(:class, "scandinavia").should exist
-      browser.option(:index, 1).should exist
-      browser.option(:xpath, "//option[@id='nor']").should exist
+      expect(browser.option(:id, "nor")).to exist
+      expect(browser.option(:id, /nor/)).to exist
+      expect(browser.option(:value, "2")).to exist
+      expect(browser.option(:value, /2/)).to exist
+      expect(browser.option(:text, "Norway")).to exist
+      expect(browser.option(:text, /Norway/)).to exist
+      expect(browser.option(:class, "scandinavia")).to exist
+      expect(browser.option(:index, 1)).to exist
+      expect(browser.option(:xpath, "//option[@id='nor']")).to exist
     end
 
     it "returns the first option if given no args" do
-      browser.option.should exist
+      expect(browser.option).to exist
     end
 
     it "returns true if the element exists (select_list context)" do
-      browser.select_list(:name, "new_user_country").option(:id, "nor").should exist
-      browser.select_list(:name, "new_user_country").option(:id, /nor/).should exist
-      browser.select_list(:name, "new_user_country").option(:value, "2").should exist
-      browser.select_list(:name, "new_user_country").option(:value, /2/).should exist
-      browser.select_list(:name, "new_user_country").option(:text, "Norway").should exist
-      browser.select_list(:name, "new_user_country").option(:text, /Norway/).should exist
-      browser.select_list(:name, "new_user_country").option(:class, "scandinavia").should exist
-      browser.select_list(:name, "new_user_country").option(:index, 1).should exist
-      browser.select_list(:name, "new_user_country").option(:xpath, "//option[@id='nor']").should exist
-      browser.select_list(:name, "new_user_country").option(:label, "Germany").should exist
+      expect(browser.select_list(:name, "new_user_country").option(:id, "nor")).to exist
+      expect(browser.select_list(:name, "new_user_country").option(:id, /nor/)).to exist
+      expect(browser.select_list(:name, "new_user_country").option(:value, "2")).to exist
+      expect(browser.select_list(:name, "new_user_country").option(:value, /2/)).to exist
+      expect(browser.select_list(:name, "new_user_country").option(:text, "Norway")).to exist
+      expect(browser.select_list(:name, "new_user_country").option(:text, /Norway/)).to exist
+      expect(browser.select_list(:name, "new_user_country").option(:class, "scandinavia")).to exist
+      expect(browser.select_list(:name, "new_user_country").option(:index, 1)).to exist
+      expect(browser.select_list(:name, "new_user_country").option(:xpath, "//option[@id='nor']")).to exist
+      expect(browser.select_list(:name, "new_user_country").option(:label, "Germany")).to exist
     end
 
     it "returns false if the element does not exist (page context)" do
-      browser.option(:id, "no_such_id").should_not exist
-      browser.option(:id, /no_such_id/).should_not exist
-      browser.option(:value, "no_such_value").should_not exist
-      browser.option(:value, /no_such_value/).should_not exist
-      browser.option(:text, "no_such_text").should_not exist
-      browser.option(:text, /no_such_text/).should_not exist
-      browser.option(:class, "no_such_class").should_not exist
-      browser.option(:index, 1337).should_not exist
-      browser.option(:xpath, "//option[@id='no_such_id']").should_not exist
+      expect(browser.option(:id, "no_such_id")).to_not exist
+      expect(browser.option(:id, /no_such_id/)).to_not exist
+      expect(browser.option(:value, "no_such_value")).to_not exist
+      expect(browser.option(:value, /no_such_value/)).to_not exist
+      expect(browser.option(:text, "no_such_text")).to_not exist
+      expect(browser.option(:text, /no_such_text/)).to_not exist
+      expect(browser.option(:class, "no_such_class")).to_not exist
+      expect(browser.option(:index, 1337)).to_not exist
+      expect(browser.option(:xpath, "//option[@id='no_such_id']")).to_not exist
     end
 
     it "returns false if the element does not exist (select_list context)" do
-      browser.select_list(:name, "new_user_country").option(:id, "no_such_id").should_not exist
-      browser.select_list(:name, "new_user_country").option(:id, /no_such_id/).should_not exist
-      browser.select_list(:name, "new_user_country").option(:value, "no_such_value").should_not exist
-      browser.select_list(:name, "new_user_country").option(:value, /no_such_value/).should_not exist
-      browser.select_list(:name, "new_user_country").option(:text, "no_such_text").should_not exist
-      browser.select_list(:name, "new_user_country").option(:text, /no_such_text/).should_not exist
-      browser.select_list(:name, "new_user_country").option(:class, "no_such_class").should_not exist
-      browser.select_list(:name, "new_user_country").option(:index, 1337).should_not exist
-      browser.select_list(:name, "new_user_country").option(:xpath, "//option[@id='no_such_id']").should_not exist
+      expect(browser.select_list(:name, "new_user_country").option(:id, "no_such_id")).to_not exist
+      expect(browser.select_list(:name, "new_user_country").option(:id, /no_such_id/)).to_not exist
+      expect(browser.select_list(:name, "new_user_country").option(:value, "no_such_value")).to_not exist
+      expect(browser.select_list(:name, "new_user_country").option(:value, /no_such_value/)).to_not exist
+      expect(browser.select_list(:name, "new_user_country").option(:text, "no_such_text")).to_not exist
+      expect(browser.select_list(:name, "new_user_country").option(:text, /no_such_text/)).to_not exist
+      expect(browser.select_list(:name, "new_user_country").option(:class, "no_such_class")).to_not exist
+      expect(browser.select_list(:name, "new_user_country").option(:index, 1337)).to_not exist
+      expect(browser.select_list(:name, "new_user_country").option(:xpath, "//option[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.option(:id, 3.14).exists? }.should raise_error(TypeError)
-      lambda { browser.select_list(:name, "new_user_country").option(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.option(:id, 3.14).exists? }.to raise_error(TypeError)
+      expect{ browser.select_list(:name, "new_user_country").option(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.option(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
-      lambda { browser.select_list(:name, "new_user_country").option(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.option(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.select_list(:name, "new_user_country").option(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   describe "#select" do
     it "selects the chosen option (page context)" do
       browser.option(:text, "Denmark").select
-      browser.select_list(:name, "new_user_country").selected_options.map(&:text).should == ["Denmark"]
+      expect(browser.select_list(:name, "new_user_country").selected_options.map(&:text)).to eq ["Denmark"]
     end
 
     it "selects the chosen option (select_list context)" do
       browser.select_list(:name, "new_user_country").option(:text, "Denmark").select
-      browser.select_list(:name, "new_user_country").selected_options.map(&:text).should == ["Denmark"]
+      expect(browser.select_list(:name, "new_user_country").selected_options.map(&:text)).to eq ["Denmark"]
     end
 
     it "selects the option when found by text (page context)" do
       browser.option(:text, 'Sweden').select
-      browser.option(:text, 'Sweden').should be_selected
+      expect(browser.option(:text, 'Sweden')).to be_selected
     end
 
     it "selects the option when found by text (select_list context)" do
       browser.select_list(:name, 'new_user_country').option(:text, 'Sweden').select
-      browser.select_list(:name, 'new_user_country').option(:text, 'Sweden').should be_selected
+      expect(browser.select_list(:name, 'new_user_country').option(:text, 'Sweden')).to be_selected
     end
 
     # there's no onclick event for Option in IE / WebKit
@@ -98,7 +98,7 @@ describe "Option" do
     compliant_on :firefox do
       it "fires the onclick event (page context)" do
         browser.option(:text, "Username 3").select
-        browser.text_field(:id, 'delete_user_comment').value.should == 'Don\'t do it!'
+        expect(browser.text_field(:id, 'delete_user_comment').value).to eq 'Don\'t do it!'
       end
     end
 
@@ -107,44 +107,44 @@ describe "Option" do
     compliant_on :firefox do
       it "fires onclick event (select_list context)" do
         browser.select_list(:id, 'delete_user_username').option(:text, "Username 3").select
-        browser.text_field(:id, 'delete_user_comment').value.should == 'Don\'t do it!'
+        expect(browser.text_field(:id, 'delete_user_comment').value).to eq 'Don\'t do it!'
       end
     end
 
     it "raises UnknownObjectException if the option does not exist (page context)" do
-      lambda { browser.option(:text, "no_such_text").select }.should raise_error(UnknownObjectException)
-      lambda { browser.option(:text, /missing/).select }.should raise_error(UnknownObjectException)
+      expect{ browser.option(:text, "no_such_text").select }.to raise_error(UnknownObjectException)
+      expect{ browser.option(:text, /missing/).select }.to raise_error(UnknownObjectException)
     end
 
     it "raises UnknownObjectException if the option does not exist (select_list context)" do
-      lambda { browser.select_list(:name, "new_user_country").option(:text, "no_such_text").select }.should raise_error(UnknownObjectException)
-      lambda { browser.select_list(:name, "new_user_country").option(:text, /missing/).select }.should raise_error(UnknownObjectException)
+      expect{ browser.select_list(:name, "new_user_country").option(:text, "no_such_text").select }.to raise_error(UnknownObjectException)
+      expect{ browser.select_list(:name, "new_user_country").option(:text, /missing/).select }.to raise_error(UnknownObjectException)
     end
 
     it "raises MissingWayOfFindingObjectException when given a bad 'how' (page context)" do
-      lambda { browser.option(:missing, "Denmark").select }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.option(:missing, "Denmark").select }.to raise_error(MissingWayOfFindingObjectException)
     end
 
     it "raises MissingWayOfFindingObjectException when given a bad 'how' (select_list context)" do
-      lambda { browser.select_list(:name, "new_user_country").option(:missing, "Denmark").select }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.select_list(:name, "new_user_country").option(:missing, "Denmark").select }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   describe "#class_name" do
     it "is able to get attributes (page context)" do
-      browser.option(:text, 'Sweden').class_name.should == "scandinavia"
+      expect(browser.option(:text, 'Sweden').class_name).to eq "scandinavia"
     end
 
     it "is able to get attributes (select_list context)" do
-      browser.select_list(:name, "new_user_country").option(:text, 'Sweden').class_name.should == "scandinavia"
+      expect(browser.select_list(:name, "new_user_country").option(:text, 'Sweden').class_name).to eq "scandinavia"
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.select_list(:name, "new_user_country").option(:text, 'Sweden').should respond_to(:class_name)
-      browser.select_list(:name, "new_user_country").option(:text, 'Sweden').should respond_to(:id)
-      browser.select_list(:name, "new_user_country").option(:text, 'Sweden').should respond_to(:text)
+      expect(browser.select_list(:name, "new_user_country").option(:text, 'Sweden')).to respond_to(:class_name)
+      expect(browser.select_list(:name, "new_user_country").option(:text, 'Sweden')).to respond_to(:id)
+      expect(browser.select_list(:name, "new_user_country").option(:text, 'Sweden')).to respond_to(:text)
     end
   end
 

--- a/p_spec.rb
+++ b/p_spec.rb
@@ -10,106 +10,106 @@ describe "P" do
   # Exists method
   describe "#exist?" do
     it "returns true if the 'p' exists" do
-      browser.p(:id, "lead").should exist
-      browser.p(:id, /lead/).should exist
-      browser.p(:text, "Dubito, ergo cogito, ergo sum.").should exist
-      browser.p(:text, /Dubito, ergo cogito, ergo sum/).should exist
-      browser.p(:class, "lead").should exist
-      browser.p(:class, /lead/).should exist
-      browser.p(:index, 0).should exist
-      browser.p(:xpath, "//p[@id='lead']").should exist
+      expect(browser.p(:id, "lead")).to exist
+      expect(browser.p(:id, /lead/)).to exist
+      expect(browser.p(:text, "Dubito, ergo cogito, ergo sum.")).to exist
+      expect(browser.p(:text, /Dubito, ergo cogito, ergo sum/)).to exist
+      expect(browser.p(:class, "lead")).to exist
+      expect(browser.p(:class, /lead/)).to exist
+      expect(browser.p(:index, 0)).to exist
+      expect(browser.p(:xpath, "//p[@id='lead']")).to exist
     end
 
     it "returns the first p if given no args" do
-      browser.p.should exist
+      expect(browser.p).to exist
     end
 
     it "returns false if the 'p' doesn't exist" do
-      browser.p(:id, "no_such_id").should_not exist
-      browser.p(:id, /no_such_id/).should_not exist
-      browser.p(:text, "no_such_text").should_not exist
-      browser.p(:text, /no_such_text/).should_not exist
-      browser.p(:class, "no_such_class").should_not exist
-      browser.p(:class, /no_such_class/).should_not exist
-      browser.p(:index, 1337).should_not exist
-      browser.p(:xpath, "//p[@id='no_such_id']").should_not exist
+      expect(browser.p(:id, "no_such_id")).to_not exist
+      expect(browser.p(:id, /no_such_id/)).to_not exist
+      expect(browser.p(:text, "no_such_text")).to_not exist
+      expect(browser.p(:text, /no_such_text/)).to_not exist
+      expect(browser.p(:class, "no_such_class")).to_not exist
+      expect(browser.p(:class, /no_such_class/)).to_not exist
+      expect(browser.p(:index, 1337)).to_not exist
+      expect(browser.p(:xpath, "//p[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.p(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.p(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.p(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.p(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Attribute methods
   describe "#class_name" do
     it "returns the class attribute" do
-      browser.p(:index, 0).class_name.should == 'lead'
+      expect(browser.p(:index, 0).class_name).to eq 'lead'
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.p(:index, 2).class_name.should == ''
+      expect(browser.p(:index, 2).class_name).to eq ''
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      lambda { browser.p(:id, 'no_such_id').class_name }.should raise_error(UnknownObjectException)
+      expect{ browser.p(:id, 'no_such_id').class_name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#id" do
     it "returns the id attribute" do
-      browser.p(:index, 0).id.should == "lead"
+      expect(browser.p(:index, 0).id).to eq "lead"
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.p(:index, 2).id.should == ''
+      expect(browser.p(:index, 2).id).to eq ''
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      lambda { browser.p(:id, "no_such_id").id }.should raise_error(UnknownObjectException)
-      lambda { browser.p(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{ browser.p(:id, "no_such_id").id }.to raise_error(UnknownObjectException)
+      expect{ browser.p(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#title" do
     it "returns the title attribute" do
-      browser.p(:index, 0).title.should == 'Lorem ipsum'
+      expect(browser.p(:index, 0).title).to eq 'Lorem ipsum'
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.p(:index, 2).title.should == ''
+      expect(browser.p(:index, 2).title).to eq ''
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      lambda { browser.p(:id, 'no_such_id').title }.should raise_error( UnknownObjectException)
-      lambda { browser.p(:xpath, "//p[@id='no_such_id']").title }.should raise_error( UnknownObjectException)
+      expect{ browser.p(:id, 'no_such_id').title }.to raise_error( UnknownObjectException)
+      expect{ browser.p(:xpath, "//p[@id='no_such_id']").title }.to raise_error( UnknownObjectException)
     end
   end
 
   describe "#text" do
     it "returns the text of the p" do
-      browser.p(:index, 1).text.should == 'Sed pretium metus et quam. Nullam odio dolor, vestibulum non, tempor ut, vehicula sed, sapien. Vestibulum placerat ligula at quam. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.'
+      expect(browser.p(:index, 1).text).to eq 'Sed pretium metus et quam. Nullam odio dolor, vestibulum non, tempor ut, vehicula sed, sapien. Vestibulum placerat ligula at quam. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.'
     end
 
     it "returns an empty string if the element doesn't contain any text" do
-      browser.p(:index, 4).text.should == ''
+      expect(browser.p(:index, 4).text).to eq ''
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      lambda { browser.p(:id, 'no_such_id').text }.should raise_error( UnknownObjectException)
-      lambda { browser.p(:xpath , "//p[@id='no_such_id']").text }.should raise_error( UnknownObjectException)
+      expect{ browser.p(:id, 'no_such_id').text }.to raise_error( UnknownObjectException)
+      expect{ browser.p(:xpath , "//p[@id='no_such_id']").text }.to raise_error( UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.p(:index, 0).should respond_to(:class_name)
-      browser.p(:index, 0).should respond_to(:id)
-      browser.p(:index, 0).should respond_to(:title)
-      browser.p(:index, 0).should respond_to(:text)
+      expect(browser.p(:index, 0)).to respond_to(:class_name)
+      expect(browser.p(:index, 0)).to respond_to(:id)
+      expect(browser.p(:index, 0)).to respond_to(:title)
+      expect(browser.p(:index, 0)).to respond_to(:text)
     end
   end
 

--- a/pre_spec.rb
+++ b/pre_spec.rb
@@ -10,106 +10,106 @@ describe "Pre" do
   # Exists method
   describe "#exist?" do
     it "returns true if the 'p' exists" do
-      browser.pre(:id, "rspec").should exist
-      browser.pre(:id, /rspec/).should exist
-      browser.pre(:text, 'browser.pre(:id, "rspec").should exist').should exist
-      browser.pre(:text, /browser\.pre/).should exist
-      browser.pre(:class, "ruby").should exist
-      browser.pre(:class, /ruby/).should exist
-      browser.pre(:index, 0).should exist
-      browser.pre(:xpath, "//pre[@id='rspec']").should exist
+      expect(browser.pre(:id, "rspec")).to exist
+      expect(browser.pre(:id, /rspec/)).to exist
+      expect(browser.pre(:text, 'browser.pre(:id, "rspec").should exist')).to exist
+      expect(browser.pre(:text, /browser\.pre/)).to exist
+      expect(browser.pre(:class, "ruby")).to exist
+      expect(browser.pre(:class, /ruby/)).to exist
+      expect(browser.pre(:index, 0)).to exist
+      expect(browser.pre(:xpath, "//pre[@id='rspec']")).to exist
     end
 
     it "returns the first pre if given no args" do
-      browser.pre.should exist
+      expect(browser.pre).to exist
     end
 
     it "returns false if the 'p' doesn't exist" do
-      browser.pre(:id, "no_such_id").should_not exist
-      browser.pre(:id, /no_such_id/).should_not exist
-      browser.pre(:text, "no_such_text").should_not exist
-      browser.pre(:text, /no_such_text/).should_not exist
-      browser.pre(:class, "no_such_class").should_not exist
-      browser.pre(:class, /no_such_class/).should_not exist
-      browser.pre(:index, 1337).should_not exist
-      browser.pre(:xpath, "//pre[@id='no_such_id']").should_not exist
+      expect(browser.pre(:id, "no_such_id")).to_not exist
+      expect(browser.pre(:id, /no_such_id/)).to_not exist
+      expect(browser.pre(:text, "no_such_text")).to_not exist
+      expect(browser.pre(:text, /no_such_text/)).to_not exist
+      expect(browser.pre(:class, "no_such_class")).to_not exist
+      expect(browser.pre(:class, /no_such_class/)).to_not exist
+      expect(browser.pre(:index, 1337)).to_not exist
+      expect(browser.pre(:xpath, "//pre[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.pre(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.pre(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.pre(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.pre(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Attribute methods
   describe "#class_name" do
     it "returns the class attribute" do
-      browser.pre(:id, 'rspec').class_name.should == 'ruby'
+      expect(browser.pre(:id, 'rspec').class_name).to eq 'ruby'
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.pre(:index, 0).class_name.should == ''
+      expect(browser.pre(:index, 0).class_name).to eq ''
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      lambda { browser.pre(:id, 'no_such_id').class_name }.should raise_error(UnknownObjectException)
+      expect{ browser.pre(:id, 'no_such_id').class_name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#id" do
     it "returns the id attribute" do
-      browser.pre(:class, 'ruby').id.should == "rspec"
+      expect(browser.pre(:class, 'ruby').id).to eq "rspec"
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.pre(:index, 0).id.should == ''
+      expect(browser.pre(:index, 0).id).to eq ''
     end
 
     it "raises UnknownObjectException if the pre doesn't exist" do
-      lambda { browser.pre(:id, "no_such_id").id }.should raise_error(UnknownObjectException)
-      lambda { browser.pre(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{ browser.pre(:id, "no_such_id").id }.to raise_error(UnknownObjectException)
+      expect{ browser.pre(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#title" do
     it "returns the title attribute" do
-      browser.pre(:class, 'brainfuck').title.should == 'The brainfuck language is an esoteric programming language noted for its extreme minimalism'
+      expect(browser.pre(:class, 'brainfuck').title).to eq 'The brainfuck language is an esoteric programming language noted for its extreme minimalism'
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.pre(:index, 0).title.should == ''
+      expect(browser.pre(:index, 0).title).to eq ''
     end
 
     it "raises UnknownObjectException if the pre doesn't exist" do
-      lambda { browser.pre(:id, 'no_such_id').title }.should raise_error( UnknownObjectException)
-      lambda { browser.pre(:xpath, "//pre[@id='no_such_id']").title }.should raise_error( UnknownObjectException)
+      expect{ browser.pre(:id, 'no_such_id').title }.to raise_error( UnknownObjectException)
+      expect{ browser.pre(:xpath, "//pre[@id='no_such_id']").title }.to raise_error( UnknownObjectException)
     end
   end
 
   describe "#text" do
     it "returns the text of the pre" do
-      browser.pre(:class, 'haskell').text.should == 'main = putStrLn "Hello World"'
+      expect(browser.pre(:class, 'haskell').text).to eq 'main = putStrLn "Hello World"'
     end
 
     it "returns an empty string if the element doesn't contain any text" do
-      browser.pre(:index, 0).text.should == ''
+      expect(browser.pre(:index, 0).text).to eq ''
     end
 
     it "raises UnknownObjectException if the pre doesn't exist" do
-      lambda { browser.pre(:id, 'no_such_id').text }.should raise_error( UnknownObjectException)
-      lambda { browser.pre(:xpath , "//pre[@id='no_such_id']").text }.should raise_error( UnknownObjectException)
+      expect{ browser.pre(:id, 'no_such_id').text }.to raise_error( UnknownObjectException)
+      expect{ browser.pre(:xpath , "//pre[@id='no_such_id']").text }.to raise_error( UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.image(:index, 0).should respond_to(:class_name)
-      browser.image(:index, 0).should respond_to(:id)
-      browser.image(:index, 0).should respond_to(:title)
-      browser.image(:index, 0).should respond_to(:text)
+      expect(browser.image(:index, 0)).to respond_to(:class_name)
+      expect(browser.image(:index, 0)).to respond_to(:id)
+      expect(browser.image(:index, 0)).to respond_to(:title)
+      expect(browser.image(:index, 0)).to respond_to(:text)
     end
   end
 

--- a/pres_spec.rb
+++ b/pres_spec.rb
@@ -10,20 +10,20 @@ describe "Pres" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.pres(:class => "c++").to_a.should == [browser.pre(:class => "c++")]
+        expect(browser.pres(:class => "c++").to_a).to eq [browser.pre(:class => "c++")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the number of pres" do
-      browser.pres.length.should == 7
+      expect(browser.pres.length).to eq 7
     end
   end
 
   describe "#[]" do
     it "returns the pre at the given index" do
-      browser.pres[1].id.should == "rspec"
+      expect(browser.pres[1].id).to eq "rspec"
     end
   end
 
@@ -32,11 +32,11 @@ describe "Pres" do
       count = 0
 
       browser.pres.each_with_index do |p, index|
-        p.id.should == browser.pre(:index, index).id
+        expect(p.id).to eq browser.pre(:index, index).id
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/ps_spec.rb
+++ b/ps_spec.rb
@@ -10,20 +10,20 @@ describe "Ps" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.ps(:class => "lead").to_a.should == [browser.p(:class => "lead")]
+        expect(browser.ps(:class => "lead").to_a).to eq [browser.p(:class => "lead")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the number of ps" do
-      browser.ps.length.should == 5
+      expect(browser.ps.length).to eq 5
     end
   end
 
   describe "#[]" do
     it "returns the p at the given index" do
-      browser.ps[0].id.should == "lead"
+      expect(browser.ps[0].id).to eq "lead"
     end
   end
 
@@ -32,11 +32,11 @@ describe "Ps" do
       count = 0
 
       browser.ps.each_with_index do |p, index|
-        p.id.should == browser.p(:index, index).id
+        expect(p.id).to eq browser.p(:index, index).id
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/radio_spec.rb
+++ b/radio_spec.rb
@@ -10,254 +10,254 @@ describe "Radio" do
   # Exists method
   describe "#exists?" do
     it "returns true if the radio button exists" do
-      browser.radio(:id, "new_user_newsletter_yes").should exist
-      browser.radio(:id, /new_user_newsletter_yes/).should exist
-      browser.radio(:name, "new_user_newsletter").should exist
-      browser.radio(:name, /new_user_newsletter/).should exist
-      browser.radio(:value, "yes").should exist
-      browser.radio(:value, /yes/).should exist
+      expect(browser.radio(:id, "new_user_newsletter_yes")).to exist
+      expect(browser.radio(:id, /new_user_newsletter_yes/)).to exist
+      expect(browser.radio(:name, "new_user_newsletter")).to exist
+      expect(browser.radio(:name, /new_user_newsletter/)).to exist
+      expect(browser.radio(:value, "yes")).to exist
+      expect(browser.radio(:value, /yes/)).to exist
       # TODO: figure out what :text means for a radio button
-      # browser.radio(:text, "yes").should exist
-      # browser.radio(:text, /yes/).should exist
-      browser.radio(:class, "huge").should exist
-      browser.radio(:class, /huge/).should exist
-      browser.radio(:index, 0).should exist
-      browser.radio(:xpath, "//input[@id='new_user_newsletter_yes']").should exist
+      # browser.radio(:text, "yes").to exist
+      # browser.radio(:text, /yes/).to exist
+      expect(browser.radio(:class, "huge")).to exist
+      expect(browser.radio(:class, /huge/)).to exist
+      expect(browser.radio(:index, 0)).to exist
+      expect(browser.radio(:xpath, "//input[@id='new_user_newsletter_yes']")).to exist
     end
 
     it "returns the first radio if given no args" do
-      browser.radio.should exist
+      expect(browser.radio).to exist
     end
 
     it "returns true if the radio button exists (search by name and value)" do
-      browser.radio(:name => "new_user_newsletter", :value => 'yes').should exist
+      expect(browser.radio(:name => "new_user_newsletter", :value => 'yes')).to exist
       browser.radio(:xpath, "//input[@name='new_user_newsletter' and @value='yes']").set
     end
 
     it "returns true for element with upper case type" do
-      browser.radio(:id, "new_user_newsletter_probably").should exist
+      expect(browser.radio(:id, "new_user_newsletter_probably")).to exist
     end
 
     it "returns false if the radio button does not exist" do
-      browser.radio(:id, "no_such_id").should_not exist
-      browser.radio(:id, /no_such_id/).should_not exist
-      browser.radio(:name, "no_such_name").should_not exist
-      browser.radio(:name, /no_such_name/).should_not exist
-      browser.radio(:value, "no_such_value").should_not exist
-      browser.radio(:value, /no_such_value/).should_not exist
-      browser.radio(:text, "no_such_text").should_not exist
-      browser.radio(:text, /no_such_text/).should_not exist
-      browser.radio(:class, "no_such_class").should_not exist
-      browser.radio(:class, /no_such_class/).should_not exist
-      browser.radio(:index, 1337).should_not exist
-      browser.radio(:xpath, "input[@id='no_such_id']").should_not exist
+      expect(browser.radio(:id, "no_such_id")).to_not exist
+      expect(browser.radio(:id, /no_such_id/)).to_not exist
+      expect(browser.radio(:name, "no_such_name")).to_not exist
+      expect(browser.radio(:name, /no_such_name/)).to_not exist
+      expect(browser.radio(:value, "no_such_value")).to_not exist
+      expect(browser.radio(:value, /no_such_value/)).to_not exist
+      expect(browser.radio(:text, "no_such_text")).to_not exist
+      expect(browser.radio(:text, /no_such_text/)).to_not exist
+      expect(browser.radio(:class, "no_such_class")).to_not exist
+      expect(browser.radio(:class, /no_such_class/)).to_not exist
+      expect(browser.radio(:index, 1337)).to_not exist
+      expect(browser.radio(:xpath, "input[@id='no_such_id']")).to_not exist
     end
 
     it "returns false if the radio button does not exist (search by name and value)" do
-      browser.radio(:name => "new_user_newsletter", :value => 'no_such_value').should_not exist
-      browser.radio(:xpath, "//input[@name='new_user_newsletter' and @value='no_such_value']").should_not exist
-      browser.radio(:name => "no_such_name", :value => 'yes').should_not exist
-      browser.radio(:xpath, "//input[@name='no_such_name' and @value='yes']").should_not exist
+      expect(browser.radio(:name => "new_user_newsletter", :value => 'no_such_value')).to_not exist
+      expect(browser.radio(:xpath, "//input[@name='new_user_newsletter' and @value='no_such_value']")).to_not exist
+      expect(browser.radio(:name => "no_such_name", :value => 'yes')).to_not exist
+      expect(browser.radio(:xpath, "//input[@name='no_such_name' and @value='yes']")).to_not exist
     end
 
     it "returns true for radios with a string value" do
-      browser.radio(:name => 'new_user_newsletter', :value => 'yes').should exist
-      browser.radio(:name => 'new_user_newsletter', :value => 'no').should exist
+      expect(browser.radio(:name => 'new_user_newsletter', :value => 'yes')).to exist
+      expect(browser.radio(:name => 'new_user_newsletter', :value => 'no')).to exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.radio(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.radio(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.radio(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.radio(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Attribute methods
   describe "#class_name" do
     it "returns the class name if the radio exists and has an attribute" do
-      browser.radio(:id, "new_user_newsletter_yes").class_name.should == "huge"
+      expect(browser.radio(:id, "new_user_newsletter_yes").class_name).to eq "huge"
     end
 
     it "returns an empty string if the radio exists and the attribute doesn't" do
-      browser.radio(:id, "new_user_newsletter_no").class_name.should == ""
+      expect(browser.radio(:id, "new_user_newsletter_no").class_name).to eq ""
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      lambda { browser.radio(:id, "no_such_id").class_name }.should raise_error(UnknownObjectException)
+      expect{ browser.radio(:id, "no_such_id").class_name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#id" do
     it "returns the id attribute if the radio exists and has an attribute" do
-      browser.radio(:index, 0).id.should == "new_user_newsletter_yes"
+      expect(browser.radio(:index, 0).id).to eq "new_user_newsletter_yes"
     end
 
     it "returns an empty string if the radio exists and the attribute doesn't" do
-      browser.radio(:index, 2).id.should == ""
+      expect(browser.radio(:index, 2).id).to eq ""
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      lambda { browser.radio(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{ browser.radio(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#name" do
     it "returns the name attribute if the radio exists" do
-      browser.radio(:id, 'new_user_newsletter_yes').name.should == "new_user_newsletter"
+      expect(browser.radio(:id, 'new_user_newsletter_yes').name).to eq "new_user_newsletter"
     end
 
     it "returns an empty string if the radio exists and the attribute doesn't" do
-      browser.radio(:id, 'new_user_newsletter_absolutely').name.should == ""
+      expect(browser.radio(:id, 'new_user_newsletter_absolutely').name).to eq ""
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      lambda { browser.radio(:index, 1337).name }.should raise_error(UnknownObjectException)
+      expect{ browser.radio(:index, 1337).name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#title" do
     it "returns the title attribute if the radio exists" do
-      browser.radio(:id, "new_user_newsletter_no").title.should == "Traitor!"
+      expect(browser.radio(:id, "new_user_newsletter_no").title).to eq "Traitor!"
     end
 
     it "returns an empty string if the radio exists and the attribute doesn't" do
-      browser.radio(:id, "new_user_newsletter_yes").title.should == ""
+      expect(browser.radio(:id, "new_user_newsletter_yes").title).to eq ""
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      lambda { browser.radio(:index, 1337).title }.should raise_error(UnknownObjectException)
+      expect{ browser.radio(:index, 1337).title }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#type" do
     it "returns the type attribute if the radio exists" do
-      browser.radio(:index, 0).type.should == "radio"
+      expect(browser.radio(:index, 0).type).to eq "radio"
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      lambda { browser.radio(:index, 1337).type }.should raise_error(UnknownObjectException)
+      expect{ browser.radio(:index, 1337).type }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#value" do
     it "returns the value attribute if the radio exists" do
-      browser.radio(:id, 'new_user_newsletter_yes').value.should == 'yes'
+      expect(browser.radio(:id, 'new_user_newsletter_yes').value).to eq 'yes'
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      lambda { browser.radio(:index, 1337).value}.should raise_error(UnknownObjectException)
+      expect{ browser.radio(:index, 1337).value}.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.radio(:index, 0).should respond_to(:class_name)
-      browser.radio(:index, 0).should respond_to(:id)
-      browser.radio(:index, 0).should respond_to(:name)
-      browser.radio(:index, 0).should respond_to(:title)
-      browser.radio(:index, 0).should respond_to(:type)
-      browser.radio(:index, 0).should respond_to(:value)
+      expect(browser.radio(:index, 0)).to respond_to(:class_name)
+      expect(browser.radio(:index, 0)).to respond_to(:id)
+      expect(browser.radio(:index, 0)).to respond_to(:name)
+      expect(browser.radio(:index, 0)).to respond_to(:title)
+      expect(browser.radio(:index, 0)).to respond_to(:type)
+      expect(browser.radio(:index, 0)).to respond_to(:value)
     end
   end
 
   # Access methods
   describe "#enabled?" do
     it "returns true if the radio button is enabled" do
-      browser.radio(:id, "new_user_newsletter_yes").should be_enabled
-      browser.radio(:xpath, "//input[@id='new_user_newsletter_yes']").should be_enabled
+      expect(browser.radio(:id, "new_user_newsletter_yes")).to be_enabled
+      expect(browser.radio(:xpath, "//input[@id='new_user_newsletter_yes']")).to be_enabled
     end
 
     it "returns false if the radio button is disabled" do
-      browser.radio(:id, "new_user_newsletter_nah").should_not be_enabled
-      browser.radio(:xpath, "//input[@id='new_user_newsletter_nah']").should_not be_enabled
+      expect(browser.radio(:id, "new_user_newsletter_nah")).to_not be_enabled
+      expect(browser.radio(:xpath, "//input[@id='new_user_newsletter_nah']")).to_not be_enabled
     end
 
     it "raises UnknownObjectException if the radio button doesn't exist" do
-      lambda { browser.radio(:id, "no_such_id").enabled?  }.should raise_error(UnknownObjectException)
-      lambda { browser.radio(:xpath, "//input[@id='no_such_id']").enabled?  }.should raise_error(UnknownObjectException)
+      expect{ browser.radio(:id, "no_such_id").enabled?  }.to raise_error(UnknownObjectException)
+      expect{ browser.radio(:xpath, "//input[@id='no_such_id']").enabled?  }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#disabled?" do
     it "returns true if the radio is disabled" do
-      browser.radio(:id, 'new_user_newsletter_nah').should be_disabled
+      expect(browser.radio(:id, 'new_user_newsletter_nah')).to be_disabled
     end
 
     it "returns false if the radio is enabled" do
-      browser.radio(:id, 'new_user_newsletter_yes').should_not be_disabled
+      expect(browser.radio(:id, 'new_user_newsletter_yes')).to_not be_disabled
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      lambda { browser.radio(:index, 1337).disabled? }.should raise_error(UnknownObjectException)
+      expect{ browser.radio(:index, 1337).disabled? }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#set" do
     it "sets the radio button" do
       browser.radio(:id, "new_user_newsletter_no").set
-      browser.radio(:id, "new_user_newsletter_no").should be_set
+      expect(browser.radio(:id, "new_user_newsletter_no")).to be_set
     end
 
     it "sets the radio button when found by :xpath" do
       browser.radio(:xpath, "//input[@id='new_user_newsletter_no']").set
-      browser.radio(:xpath, "//input[@id='new_user_newsletter_no']").should be_set
+      expect(browser.radio(:xpath, "//input[@id='new_user_newsletter_no']")).to be_set
     end
 
     it "fires the onclick event" do
       browser.radio(:id, "new_user_newsletter_no").set
       browser.radio(:id, "new_user_newsletter_yes").set
-      messages.should == ["clicked: new_user_newsletter_no", "clicked: new_user_newsletter_yes"]
+      expect(messages).to eq ["clicked: new_user_newsletter_no", "clicked: new_user_newsletter_yes"]
     end
 
     # http://webbugtrack.blogspot.com/2007/11/bug-193-onchange-does-not-fire-properly.html
     not_compliant_on :internet_explorer do
       it "fires the onchange event" do
         browser.radio(:value, 'certainly').set
-        messages.should == ["changed: new_user_newsletter"]
+        expect(messages).to eq ["changed: new_user_newsletter"]
 
         browser.radio(:value, 'certainly').set
-        messages.should == ["changed: new_user_newsletter"] # no event fired here - didn't change
+        expect(messages).to eq ["changed: new_user_newsletter"] # no event fired here - didn't change
 
         browser.radio(:value, 'yes').set
         browser.radio(:value, 'certainly').set
-        messages.should == ["changed: new_user_newsletter", "clicked: new_user_newsletter_yes", "changed: new_user_newsletter"]
+        expect(messages).to eq ["changed: new_user_newsletter", "clicked: new_user_newsletter_yes", "changed: new_user_newsletter"]
       end
     end
 
     it "raises UnknownObjectException if the radio button doesn't exist" do
-      lambda { browser.radio(:name, "no_such_name").set  }.should raise_error(UnknownObjectException)
-      lambda { browser.radio(:xpath, "//input[@name='no_such_name']").set  }.should raise_error(UnknownObjectException)
+      expect{ browser.radio(:name, "no_such_name").set  }.to raise_error(UnknownObjectException)
+      expect{ browser.radio(:xpath, "//input[@name='no_such_name']").set  }.to raise_error(UnknownObjectException)
     end
 
     it "raises ObjectDisabledException if the radio is disabled" do
-      lambda { browser.radio(:id, "new_user_newsletter_nah").set  }.should raise_error(ObjectDisabledException)
-      lambda { browser.radio(:xpath, "//input[@id='new_user_newsletter_nah']").set  }.should raise_error(ObjectDisabledException )
+      expect{ browser.radio(:id, "new_user_newsletter_nah").set  }.to raise_error(ObjectDisabledException)
+      expect{ browser.radio(:xpath, "//input[@id='new_user_newsletter_nah']").set  }.to raise_error(ObjectDisabledException )
     end
   end
 
   # Other
   describe '#set?' do
     it "returns true if the radio button is set" do
-      browser.radio(:id, "new_user_newsletter_yes").should be_set
+      expect(browser.radio(:id, "new_user_newsletter_yes")).to be_set
     end
 
     it "returns false if the radio button unset" do
-      browser.radio(:id, "new_user_newsletter_no").should_not be_set
+      expect(browser.radio(:id, "new_user_newsletter_no")).to_not be_set
     end
 
     it "returns the state for radios with string values" do
-      browser.radio(:name => "new_user_newsletter", :value => 'no').should_not be_set
+      expect(browser.radio(:name => "new_user_newsletter", :value => 'no')).to_not be_set
       browser.radio(:name => "new_user_newsletter", :value => 'no').set
-      browser.radio(:name => "new_user_newsletter", :value => 'no').should be_set
+      expect(browser.radio(:name => "new_user_newsletter", :value => 'no')).to be_set
       browser.radio(:name => "new_user_newsletter", :value => 'yes').set
-      browser.radio(:name => "new_user_newsletter", :value => 'no').should_not be_set
+      expect(browser.radio(:name => "new_user_newsletter", :value => 'no')).to_not be_set
     end
 
     it "raises UnknownObjectException if the radio button doesn't exist" do
-      lambda { browser.radio(:id, "no_such_id").set?  }.should raise_error(UnknownObjectException)
-      lambda { browser.radio(:xpath, "//input[@id='no_such_id']").set?  }.should raise_error(UnknownObjectException)
+      expect{ browser.radio(:id, "no_such_id").set?  }.to raise_error(UnknownObjectException)
+      expect{ browser.radio(:xpath, "//input[@id='no_such_id']").set?  }.to raise_error(UnknownObjectException)
     end
   end
 

--- a/radios_spec.rb
+++ b/radios_spec.rb
@@ -10,20 +10,20 @@ describe "Radios" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.radios(:value => "yes").to_a.should == [browser.radio(:value => "yes")]
+        expect(browser.radios(:value => "yes").to_a).to eq [browser.radio(:value => "yes")]
       end
     end
   end
 
   describe "#length" do
     it "returns the number of radios" do
-      browser.radios.length.should == 6
+      expect(browser.radios.length).to eq 6
     end
   end
 
   describe "#[]" do
     it "returns the radio button at the given index" do
-      browser.radios[0].id.should == "new_user_newsletter_yes"
+      expect(browser.radios[0].id).to eq "new_user_newsletter_yes"
     end
   end
 
@@ -32,14 +32,14 @@ describe "Radios" do
       count = 0
 
       browser.radios.each_with_index do |r, index|
-        r.name.should == browser.radio(:index, index).name
-        r.id.should ==  browser.radio(:index, index).id
-        r.value.should == browser.radio(:index, index).value
+        expect(r.name).to eq browser.radio(:index, index).name
+        expect(r.id).to eq  browser.radio(:index, index).id
+        expect(r.value).to eq browser.radio(:index, index).value
 
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/screenshot_spec.rb
+++ b/screenshot_spec.rb
@@ -11,24 +11,24 @@ describe "Watir::Screenshot" do
 
   describe '#png' do
     it 'gets png representation of screenshot' do
-      browser.screenshot.png[0..3].should == png_header
+      expect(browser.screenshot.png[0..3]).to eq png_header
     end
   end
 
   describe '#base64' do
     it 'gets base64 representation of screenshot' do
       image = browser.screenshot.base64
-      Base64.decode64(image)[0..3].should == png_header
+      expect(Base64.decode64(image)[0..3]).to eq png_header
     end
   end
 
   describe '#save' do
     it 'saves screenshot to given file' do
       path = "#{Dir.tmpdir}/test#{Time.now.to_i}.png"
-      File.should_not exist(path)
+      expect(File).to_not exist(path)
       browser.screenshot.save(path)
-      File.should exist(path)
-      File.open(path, "rb") {|io| io.read}[0..3].should == png_header
+      expect(File).to exist(path)
+      expect(File.open(path, "rb") {|io| io.read}[0..3]).to eq png_header
     end
   end
 end

--- a/select_list_spec.rb
+++ b/select_list_spec.rb
@@ -10,139 +10,139 @@ describe "SelectList" do
   # Exists method
   describe "#exists?" do
     it "returns true if the select list exists" do
-      browser.select_list(:id, 'new_user_country').should exist
-      browser.select_list(:id, /new_user_country/).should exist
-      browser.select_list(:name, 'new_user_country').should exist
-      browser.select_list(:name, /new_user_country/).should exist
+      expect(browser.select_list(:id, 'new_user_country')).to exist
+      expect(browser.select_list(:id, /new_user_country/)).to exist
+      expect(browser.select_list(:name, 'new_user_country')).to exist
+      expect(browser.select_list(:name, /new_user_country/)).to exist
 
       not_compliant_on :webdriver, :watir_classic do
-        browser.select_list(:text, 'Norway').should exist
-        browser.select_list(:text, /Norway/).should exist
+        expect(browser.select_list(:text, 'Norway')).to exist
+        expect(browser.select_list(:text, /Norway/)).to exist
       end
 
-      browser.select_list(:class, 'country').should exist
-      browser.select_list(:class, /country/).should exist
-      browser.select_list(:index, 0).should exist
-      browser.select_list(:xpath, "//select[@id='new_user_country']").should exist
+      expect(browser.select_list(:class, 'country')).to exist
+      expect(browser.select_list(:class, /country/)).to exist
+      expect(browser.select_list(:index, 0)).to exist
+      expect(browser.select_list(:xpath, "//select[@id='new_user_country']")).to exist
     end
 
     it "returns the first select if given no args" do
-      browser.select_list.should exist
+      expect(browser.select_list).to exist
     end
 
     it "returns false if the select list doesn't exist" do
-      browser.select_list(:id, 'no_such_id').should_not exist
-      browser.select_list(:id, /no_such_id/).should_not exist
-      browser.select_list(:name, 'no_such_name').should_not exist
-      browser.select_list(:name, /no_such_name/).should_not exist
-      browser.select_list(:value, 'no_such_value').should_not exist
-      browser.select_list(:value, /no_such_value/).should_not exist
-      browser.select_list(:text, 'no_such_text').should_not exist
-      browser.select_list(:text, /no_such_text/).should_not exist
-      browser.select_list(:class, 'no_such_class').should_not exist
-      browser.select_list(:class, /no_such_class/).should_not exist
-      browser.select_list(:index, 1337).should_not exist
-      browser.select_list(:xpath, "//select[@id='no_such_id']").should_not exist
+      expect(browser.select_list(:id, 'no_such_id')).to_not exist
+      expect(browser.select_list(:id, /no_such_id/)).to_not exist
+      expect(browser.select_list(:name, 'no_such_name')).to_not exist
+      expect(browser.select_list(:name, /no_such_name/)).to_not exist
+      expect(browser.select_list(:value, 'no_such_value')).to_not exist
+      expect(browser.select_list(:value, /no_such_value/)).to_not exist
+      expect(browser.select_list(:text, 'no_such_text')).to_not exist
+      expect(browser.select_list(:text, /no_such_text/)).to_not exist
+      expect(browser.select_list(:class, 'no_such_class')).to_not exist
+      expect(browser.select_list(:class, /no_such_class/)).to_not exist
+      expect(browser.select_list(:index, 1337)).to_not exist
+      expect(browser.select_list(:xpath, "//select[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.select_list(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.select_list(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.select_list(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.select_list(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Attribute methods
   describe "#class_name" do
     it "returns the class name of the select list" do
-      browser.select_list(:name, 'new_user_country').class_name.should == 'country'
+      expect(browser.select_list(:name, 'new_user_country').class_name).to eq 'country'
     end
 
     it "raises UnknownObjectException if the select list doesn't exist" do
-      lambda { browser.select_list(:name, 'no_such_name').class_name }.should raise_error(UnknownObjectException)
+      expect{ browser.select_list(:name, 'no_such_name').class_name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#id" do
     it "returns the id of the element" do
-      browser.select_list(:index, 0).id.should == "new_user_country"
+      expect(browser.select_list(:index, 0).id).to eq "new_user_country"
     end
 
     it "raises UnknownObjectException if the select list doesn't exist" do
-      lambda { browser.select_list(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{ browser.select_list(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#name" do
     it "returns the name of the element" do
-      browser.select_list(:index, 0).name.should == "new_user_country"
+      expect(browser.select_list(:index, 0).name).to eq "new_user_country"
     end
 
     it "raises UnknownObjectException if the select list doesn't exist" do
-      lambda { browser.select_list(:index, 1337).name }.should raise_error(UnknownObjectException)
+      expect{ browser.select_list(:index, 1337).name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#multiple?" do
     it "knows whether the select list allows multiple selections" do
-      browser.select_list(:index, 0).should_not be_multiple
-      browser.select_list(:index, 1).should be_multiple
+      expect(browser.select_list(:index, 0)).to_not be_multiple
+      expect(browser.select_list(:index, 1)).to be_multiple
     end
 
     it "raises UnknownObjectException if the select list doesn't exist" do
-      lambda { browser.select_list(:index, 1337).multiple? }.should raise_error(UnknownObjectException)
+      expect{ browser.select_list(:index, 1337).multiple? }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#value" do
     it "returns the value of the selected option" do
-      browser.select_list(:index, 0).value.should == "2"
+      expect(browser.select_list(:index, 0).value).to eq "2"
       browser.select_list(:index, 0).select(/Sweden/)
-      browser.select_list(:index, 0).value.should == "3"
+      expect(browser.select_list(:index, 0).value).to eq "3"
     end
 
     it "raises UnknownObjectException if the select list doesn't exist" do
-      lambda { browser.select_list(:index, 1337).value }.should raise_error(UnknownObjectException)
+      expect{ browser.select_list(:index, 1337).value }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.select_list(:index, 0).should respond_to(:class_name)
-      browser.select_list(:index, 0).should respond_to(:id)
-      browser.select_list(:index, 0).should respond_to(:name)
-      browser.select_list(:index, 0).should respond_to(:value)
+      expect(browser.select_list(:index, 0)).to respond_to(:class_name)
+      expect(browser.select_list(:index, 0)).to respond_to(:id)
+      expect(browser.select_list(:index, 0)).to respond_to(:name)
+      expect(browser.select_list(:index, 0)).to respond_to(:value)
     end
   end
 
   # Access methods
   describe "#enabled?" do
     it "returns true if the select list is enabled" do
-      browser.select_list(:name, 'new_user_country').should be_enabled
+      expect(browser.select_list(:name, 'new_user_country')).to be_enabled
     end
 
     it "returns false if the select list is disabled" do
-      browser.select_list(:name, 'new_user_role').should_not be_enabled
+      expect(browser.select_list(:name, 'new_user_role')).to_not be_enabled
     end
 
     it "raises UnknownObjectException if the select_list doesn't exist" do
-      lambda { browser.select_list(:name, 'no_such_name').enabled? }.should raise_error(UnknownObjectException)
+      expect{ browser.select_list(:name, 'no_such_name').enabled? }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#disabled?" do
     it "returns true if the select list is disabled" do
-      browser.select_list(:index, 2).should be_disabled
+      expect(browser.select_list(:index, 2)).to be_disabled
     end
 
     it "returns false if the select list is enabled" do
-      browser.select_list(:index, 0).should_not be_disabled
+      expect(browser.select_list(:index, 0)).to_not be_disabled
     end
 
     it "should raise UnknownObjectException when the select list does not exist" do
-      lambda { browser.select_list(:index, 1337).disabled? }.should raise_error(UnknownObjectException)
+      expect{ browser.select_list(:index, 1337).disabled? }.to raise_error(UnknownObjectException)
     end
   end
 
@@ -150,158 +150,158 @@ describe "SelectList" do
   describe "#option" do
     it "returns an instance of Option" do
       option = browser.select_list(:name, "new_user_country").option(:text, "Denmark")
-      option.should be_instance_of(Option)
-      option.value.should == "1"
+      expect(option).to be_instance_of(Option)
+      expect(option.value).to eq "1"
     end
   end
 
   describe "#options" do
     it "returns all the options" do
       options = browser.select_list(:name, "new_user_country").options
-      options.map(&:text).should == ["Denmark", "Norway", "Sweden", "United Kingdom", "USA", "Germany"]
+      expect(options.map(&:text)).to eq ["Denmark", "Norway", "Sweden", "United Kingdom", "USA", "Germany"]
     end
   end
 
   describe "#selected_options" do
     not_compliant_on :safariwatir do
       it "should raise UnknownObjectException if the select list doesn't exist" do
-        lambda { browser.select_list(:name, 'no_such_name').selected_options }.should raise_error(UnknownObjectException)
+        expect{ browser.select_list(:name, 'no_such_name').selected_options }.to raise_error(UnknownObjectException)
       end
     end
 
     it "gets the currently selected item(s)" do
-      browser.select_list(:name, "new_user_country").selected_options.map(&:text).should == ["Norway"]
-      browser.select_list(:name, "new_user_languages").selected_options.map(&:text).should == ["English", "Norwegian"]
+      expect(browser.select_list(:name, "new_user_country").selected_options.map(&:text)).to eq ["Norway"]
+      expect(browser.select_list(:name, "new_user_languages").selected_options.map(&:text)).to eq ["English", "Norwegian"]
     end
   end
 
   describe "#clear" do
     it "clears the selection when possible" do
       browser.select_list(:name, "new_user_languages").clear
-      browser.select_list(:name, "new_user_languages").selected_options.should be_empty
+      expect(browser.select_list(:name, "new_user_languages").selected_options).to be_empty
     end
 
     it "does not clear selections if the select list does not allow multiple selections" do
-      lambda {
+      expect{
         browser.select_list(:name, "new_user_country").clear
-      }.should raise_error(/you can only clear multi-selects/)
+      }.to raise_error(/you can only clear multi-selects/)
 
-      browser.select_list(:name, "new_user_country").selected_options.map(&:text).should == ["Norway"]
+      expect(browser.select_list(:name, "new_user_country").selected_options.map(&:text)).to eq ["Norway"]
     end
 
     it "raises UnknownObjectException if the select list doesn't exist" do
-      lambda { browser.select_list(:name, 'no_such_name').clear }.should raise_error(UnknownObjectException)
+      expect{ browser.select_list(:name, 'no_such_name').clear }.to raise_error(UnknownObjectException)
     end
 
     it "fires onchange event" do
       browser.select_list(:name, "new_user_languages").clear
-      messages.size.should == 2
+      expect(messages.size).to eq 2
     end
 
     it "doesn't fire onchange event for already cleared option" do
       browser.select_list(:name, "new_user_languages").option.clear
-      messages.size.should == 0
+      expect(messages.size).to eq 0
     end
   end
 
   describe "#include?" do
     it "returns true if the given option exists" do
-      browser.select_list(:name, 'new_user_country').should include('Denmark')
+      expect(browser.select_list(:name, 'new_user_country')).to include('Denmark')
     end
 
     it "returns false if the given option doesn't exist" do
-      browser.select_list(:name, 'new_user_country').should_not include('Ireland')
+      expect(browser.select_list(:name, 'new_user_country')).to_not include('Ireland')
     end
   end
 
   describe "#selected?" do
     it "returns true if the given option is selected" do
       browser.select_list(:name, 'new_user_country').select('Denmark')
-      browser.select_list(:name, 'new_user_country').should be_selected('Denmark')
+      expect(browser.select_list(:name, 'new_user_country')).to be_selected('Denmark')
     end
 
     it "returns false if the given option is not selected" do
-      browser.select_list(:name, 'new_user_country').should_not be_selected('Sweden')
+      expect(browser.select_list(:name, 'new_user_country')).to_not be_selected('Sweden')
     end
 
     it "raises UnknownObjectException if the option doesn't exist" do
-      lambda { browser.select_list(:name, 'new_user_country').selected?('missing_option') }.should raise_error(UnknownObjectException)
+      expect{ browser.select_list(:name, 'new_user_country').selected?('missing_option') }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#select" do
     it "selects the given item when given a String" do
       browser.select_list(:name, "new_user_country").select("Denmark")
-      browser.select_list(:name, "new_user_country").selected_options.map(&:text).should == ["Denmark"]
+      expect(browser.select_list(:name, "new_user_country").selected_options.map(&:text)).to eq ["Denmark"]
     end
 
     it "selects options by label" do
       browser.select_list(:name, "new_user_country").select("Germany")
-      browser.select_list(:name, "new_user_country").selected_options.map(&:text).should == ["Germany"]
+      expect(browser.select_list(:name, "new_user_country").selected_options.map(&:text)).to eq ["Germany"]
     end
 
     it "selects the given item when given a Regexp" do
       browser.select_list(:name, "new_user_country").select(/Denmark/)
-      browser.select_list(:name, "new_user_country").selected_options.map(&:text).should == ["Denmark"]
+      expect(browser.select_list(:name, "new_user_country").selected_options.map(&:text)).to eq ["Denmark"]
     end
 
     it "selects the given item when given an Xpath" do
       browser.select_list(:xpath, "//select[@name='new_user_country']").select("Denmark")
-      browser.select_list(:xpath, "//select[@name='new_user_country']").selected_options.map(&:text).should == ["Denmark"]
+      expect(browser.select_list(:xpath, "//select[@name='new_user_country']").selected_options.map(&:text)).to eq ["Denmark"]
     end
 
     it "selects multiple items using :name and a String" do
       browser.select_list(:name, "new_user_languages").clear
       browser.select_list(:name, "new_user_languages").select("Danish")
       browser.select_list(:name, "new_user_languages").select("Swedish")
-      browser.select_list(:name, "new_user_languages").selected_options.map(&:text).should == ["Danish", "Swedish"]
+      expect(browser.select_list(:name, "new_user_languages").selected_options.map(&:text)).to eq ["Danish", "Swedish"]
     end
 
     it "selects multiple items using :name and a Regexp" do
       browser.select_list(:name, "new_user_languages").clear
       browser.select_list(:name, "new_user_languages").select(/ish/)
-      browser.select_list(:name, "new_user_languages").selected_options.map(&:text).should == ["Danish", "English", "Swedish"]
+      expect(browser.select_list(:name, "new_user_languages").selected_options.map(&:text)).to eq ["Danish", "English", "Swedish"]
     end
 
     it "selects multiple items using :xpath" do
       browser.select_list(:xpath, "//select[@name='new_user_languages']").clear
       browser.select_list(:xpath, "//select[@name='new_user_languages']").select(/ish/)
-      browser.select_list(:xpath, "//select[@name='new_user_languages']").selected_options.map(&:text).should == ["Danish", "English", "Swedish"]
+      expect(browser.select_list(:xpath, "//select[@name='new_user_languages']").selected_options.map(&:text)).to eq ["Danish", "English", "Swedish"]
     end
 
     it "selects empty options" do
       browser.select_list(:id, "delete_user_username").select("")
-      browser.select_list(:id, "delete_user_username").selected_options.map(&:text).should == [""]
+      expect(browser.select_list(:id, "delete_user_username").selected_options.map(&:text)).to eq [""]
     end
 
     it "returns the value selected" do
-      browser.select_list(:name, "new_user_languages").select("Danish").should == "Danish"
+      expect(browser.select_list(:name, "new_user_languages").select("Danish")).to eq "Danish"
     end
 
     it "returns the first matching value if there are multiple matches" do
-      browser.select_list(:name, "new_user_languages").select(/ish/).should == "Danish"
+      expect(browser.select_list(:name, "new_user_languages").select(/ish/)).to eq "Danish"
     end
 
     it "fires onchange event when selecting an item" do
       browser.select_list(:id, "new_user_languages").select("Danish")
-      messages.should == ['changed language']
+      expect(messages).to eq ['changed language']
     end
 
     it "doesn't fire onchange event when selecting an already selected item" do
       browser.select_list(:id, "new_user_languages").clear # removes the two pre-selected options
       browser.select_list(:id, "new_user_languages").select("English")
-      messages.size.should == 3
+      expect(messages.size).to eq 3
 
       browser.select_list(:id, "new_user_languages").select("English")
-      messages.size.should == 3
+      expect(messages.size).to eq 3
     end
 
     it "returns the text of the selected option" do
-      browser.select_list(:id, "new_user_languages").select("English").should == "English"
+      expect(browser.select_list(:id, "new_user_languages").select("English")).to eq "English"
     end
 
     it "returns an empty string when selecting an option that disappears when selected" do
-      browser.select_list(:id, 'obsolete').select('sweden').should == ''
+      expect(browser.select_list(:id, 'obsolete').select('sweden')).to eq ''
     end
 
     it "selects options with a single-quoted value" do
@@ -309,12 +309,12 @@ describe "SelectList" do
     end
 
     it "raises NoValueFoundException if the option doesn't exist" do
-      lambda { browser.select_list(:name, "new_user_country").select("missing_option") }.should raise_error(NoValueFoundException)
-      lambda { browser.select_list(:name, "new_user_country").select(/missing_option/) }.should raise_error(NoValueFoundException)
+      expect{ browser.select_list(:name, "new_user_country").select("missing_option") }.to raise_error(NoValueFoundException)
+      expect{ browser.select_list(:name, "new_user_country").select(/missing_option/) }.to raise_error(NoValueFoundException)
     end
 
     it "raises a TypeError if argument is not a String, Regexp or Numeric" do
-      lambda { browser.select_list(:id, "new_user_languages").select([]) }.should raise_error(TypeError)
+      expect{ browser.select_list(:id, "new_user_languages").select([]) }.to raise_error(TypeError)
     end
   end
 
@@ -323,18 +323,18 @@ describe "SelectList" do
     it "selects the item by value string" do
       browser.select_list(:name, "new_user_languages").clear
       browser.select_list(:name, "new_user_languages").select_value("2")
-      browser.select_list(:name, "new_user_languages").selected_options.map(&:text).should == %w[English]
+      expect(browser.select_list(:name, "new_user_languages").selected_options.map(&:text)).to eq %w[English]
     end
 
     it "selects the items by value regexp" do
       browser.select_list(:name, "new_user_languages").clear
       browser.select_list(:name, "new_user_languages").select_value(/1|3/)
-      browser.select_list(:name, "new_user_languages").selected_options.map(&:text).should == %w[Danish Norwegian]
+      expect(browser.select_list(:name, "new_user_languages").selected_options.map(&:text)).to eq %w[Danish Norwegian]
     end
 
     it "raises NoValueFoundException if the option doesn't exist" do
-      lambda { browser.select_list(:name, "new_user_languages").select_value("no_such_option") }.should raise_error(NoValueFoundException)
-      lambda { browser.select_list(:name, "new_user_languages").select_value(/no_such_option/) }.should raise_error(NoValueFoundException)
+      expect{ browser.select_list(:name, "new_user_languages").select_value("no_such_option") }.to raise_error(NoValueFoundException)
+      expect{ browser.select_list(:name, "new_user_languages").select_value(/no_such_option/) }.to raise_error(NoValueFoundException)
     end
   end
 

--- a/select_lists_spec.rb
+++ b/select_lists_spec.rb
@@ -10,23 +10,23 @@ describe "SelectLists" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.select_lists(:name => "delete_user_username").to_a.should == [browser.select_list(:name => "delete_user_username")]
+        expect(browser.select_lists(:name => "delete_user_username").to_a).to eq [browser.select_list(:name => "delete_user_username")]
       end
     end
   end
 
   describe "#length" do
     it "returns the correct number of select lists on the page" do
-      browser.select_lists.length.should == 6
+      expect(browser.select_lists.length).to eq 6
     end
   end
 
   describe "#[]" do
     it "returns the correct item" do
-      browser.select_lists[0].value.should == "2"
-      browser.select_lists[0].name.should == "new_user_country"
-      browser.select_lists[0].should_not be_multiple
-      browser.select_lists[1].should be_multiple
+      expect(browser.select_lists[0].value).to eq "2"
+      expect(browser.select_lists[0].name).to eq "new_user_country"
+      expect(browser.select_lists[0]).to_not be_multiple
+      expect(browser.select_lists[1]).to be_multiple
     end
   end
 
@@ -35,14 +35,14 @@ describe "SelectLists" do
       count = 0
 
       browser.select_lists.each_with_index do |l, index|
-        browser.select_list(:index, index).name.should == l.name
-        browser.select_list(:index, index).id.should ==  l.id
-        browser.select_list(:index, index).value.should == l.value
+        expect(browser.select_list(:index, index).name).to eq l.name
+        expect(browser.select_list(:index, index).id).to eq  l.id
+        expect(browser.select_list(:index, index).value).to eq l.value
 
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/span_spec.rb
+++ b/span_spec.rb
@@ -10,120 +10,120 @@ describe "Span" do
   # Exists method
   describe "#exist?" do
     it "returns true if the 'span' exists" do
-      browser.span(:id, "lead").should exist
-      browser.span(:id, /lead/).should exist
-      browser.span(:text, "Dubito, ergo cogito, ergo sum.").should exist
-      browser.span(:text, /Dubito, ergo cogito, ergo sum/).should exist
-      browser.span(:class, "lead").should exist
-      browser.span(:class, /lead/).should exist
-      browser.span(:index, 0).should exist
-      browser.span(:xpath, "//span[@id='lead']").should exist
+      expect(browser.span(:id, "lead")).to exist
+      expect(browser.span(:id, /lead/)).to exist
+      expect(browser.span(:text, "Dubito, ergo cogito, ergo sum.")).to exist
+      expect(browser.span(:text, /Dubito, ergo cogito, ergo sum/)).to exist
+      expect(browser.span(:class, "lead")).to exist
+      expect(browser.span(:class, /lead/)).to exist
+      expect(browser.span(:index, 0)).to exist
+      expect(browser.span(:xpath, "//span[@id='lead']")).to exist
     end
 
     it "returns the first span if given no args" do
-      browser.span.should exist
+      expect(browser.span).to exist
     end
 
     it "returns false if the element doesn't exist" do
-      browser.span(:id, "no_such_id").should_not exist
-      browser.span(:id, /no_such_id/).should_not exist
-      browser.span(:text, "no_such_text").should_not exist
-      browser.span(:text, /no_such_text/).should_not exist
-      browser.span(:class, "no_such_class").should_not exist
-      browser.span(:class, /no_such_class/).should_not exist
-      browser.span(:index, 1337).should_not exist
-      browser.span(:xpath, "//span[@id='no_such_id']").should_not exist
+      expect(browser.span(:id, "no_such_id")).to_not exist
+      expect(browser.span(:id, /no_such_id/)).to_not exist
+      expect(browser.span(:text, "no_such_text")).to_not exist
+      expect(browser.span(:text, /no_such_text/)).to_not exist
+      expect(browser.span(:class, "no_such_class")).to_not exist
+      expect(browser.span(:class, /no_such_class/)).to_not exist
+      expect(browser.span(:index, 1337)).to_not exist
+      expect(browser.span(:xpath, "//span[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.span(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.span(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.span(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.span(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Attribute methods
   describe "#class_name" do
     it "returns the class attribute" do
-      browser.span(:index, 0).class_name.should == 'lead'
+      expect(browser.span(:index, 0).class_name).to eq 'lead'
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.span(:index, 2).class_name.should == ''
+      expect(browser.span(:index, 2).class_name).to eq ''
     end
 
     it "raises UnknownObjectException if the span doesn't exist" do
-      lambda { browser.span(:id, 'no_such_id').class_name }.should raise_error(UnknownObjectException)
+      expect{ browser.span(:id, 'no_such_id').class_name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#id" do
     it "returns the id attribute" do
-      browser.span(:index, 0).id.should == "lead"
+      expect(browser.span(:index, 0).id).to eq "lead"
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.span(:index, 2).id.should == ''
+      expect(browser.span(:index, 2).id).to eq ''
     end
 
     it "raises UnknownObjectException if the span doesn't exist" do
-      lambda { browser.span(:id, "no_such_id").id }.should raise_error(UnknownObjectException)
-      lambda { browser.span(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{ browser.span(:id, "no_such_id").id }.to raise_error(UnknownObjectException)
+      expect{ browser.span(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#title" do
     it "returns the title attribute" do
-      browser.span(:index, 0).title.should == 'Lorem ipsum'
+      expect(browser.span(:index, 0).title).to eq 'Lorem ipsum'
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.span(:index, 2).title.should == ''
+      expect(browser.span(:index, 2).title).to eq ''
     end
 
     it "raises UnknownObjectException if the span doesn't exist" do
-      lambda { browser.span(:id, 'no_such_id').title }.should raise_error( UnknownObjectException)
-      lambda { browser.span(:xpath, "//span[@id='no_such_id']").title }.should raise_error( UnknownObjectException)
+      expect{ browser.span(:id, 'no_such_id').title }.to raise_error( UnknownObjectException)
+      expect{ browser.span(:xpath, "//span[@id='no_such_id']").title }.to raise_error( UnknownObjectException)
     end
   end
 
   describe "#text" do
     it "returns the text of the span" do
-      browser.span(:index, 1).text.should == 'Sed pretium metus et quam. Nullam odio dolor, vestibulum non, tempor ut, vehicula sed, sapien. Vestibulum placerat ligula at quam. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.'
+      expect(browser.span(:index, 1).text).to eq 'Sed pretium metus et quam. Nullam odio dolor, vestibulum non, tempor ut, vehicula sed, sapien. Vestibulum placerat ligula at quam. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.'
     end
 
     it "returns an empty string if the element doesn't contain any text" do
-      browser.span(:index, 4).text.should == ''
+      expect(browser.span(:index, 4).text).to eq ''
     end
 
     it "raises UnknownObjectException if the span doesn't exist" do
-      lambda { browser.span(:id, 'no_such_id').text }.should raise_error( UnknownObjectException)
-      lambda { browser.span(:xpath , "//span[@id='no_such_id']").text }.should raise_error( UnknownObjectException)
+      expect{ browser.span(:id, 'no_such_id').text }.to raise_error( UnknownObjectException)
+      expect{ browser.span(:xpath , "//span[@id='no_such_id']").text }.to raise_error( UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.span(:index, 0).should respond_to(:class_name)
-      browser.span(:index, 0).should respond_to(:id)
-      browser.span(:index, 0).should respond_to(:title)
-      browser.span(:index, 0).should respond_to(:text)
+      expect(browser.span(:index, 0)).to respond_to(:class_name)
+      expect(browser.span(:index, 0)).to respond_to(:id)
+      expect(browser.span(:index, 0)).to respond_to(:title)
+      expect(browser.span(:index, 0)).to respond_to(:text)
     end
   end
 
   # Other
   describe "#click" do
     it "fires events" do
-      browser.span(:class, 'footer').text.should_not include('Javascript')
+      expect(browser.span(:class, 'footer').text).to_not include('Javascript')
       browser.span(:class, 'footer').click
-      browser.span(:class, 'footer').text.should include('Javascript')
+      expect(browser.span(:class, 'footer').text).to include('Javascript')
     end
 
     it "raises UnknownObjectException if the span doesn't exist" do
-      lambda { browser.span(:id, "no_such_id").click }.should raise_error(UnknownObjectException)
-      lambda { browser.span(:title, "no_such_title").click }.should raise_error(UnknownObjectException)
+      expect{ browser.span(:id, "no_such_id").click }.to raise_error(UnknownObjectException)
+      expect{ browser.span(:title, "no_such_title").click }.to raise_error(UnknownObjectException)
     end
   end
 

--- a/spans_spec.rb
+++ b/spans_spec.rb
@@ -10,20 +10,20 @@ describe "Spans" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.spans(:class => "footer").to_a.should == [browser.span(:class => "footer")]
+        expect(browser.spans(:class => "footer").to_a).to eq [browser.span(:class => "footer")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the number of spans" do
-      browser.spans.length.should == 6
+      expect(browser.spans.length).to eq 6
     end
   end
 
   describe "#[]" do
     it "returns the p at the given index" do
-      browser.spans[0].id.should == "lead"
+      expect(browser.spans[0].id).to eq "lead"
     end
   end
 
@@ -32,11 +32,11 @@ describe "Spans" do
       count = 0
 
       browser.spans.each_with_index do |s, index|
-        s.id.should == browser.span(:index, index).id
+        expect(s.id).to eq browser.span(:index, index).id
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/strong_spec.rb
+++ b/strong_spec.rb
@@ -10,82 +10,82 @@ describe "Strong" do
   # Exists method
   describe "#exist?" do
     it "returns true if the element exists" do
-      browser.strong(:id, "descartes").should exist
-      browser.strong(:id, /descartes/).should exist
-      browser.strong(:text, "Dubito, ergo cogito, ergo sum.").should exist
-      browser.strong(:text, /Dubito, ergo cogito, ergo sum/).should exist
-      browser.strong(:class, "descartes").should exist
-      browser.strong(:class, /descartes/).should exist
-      browser.strong(:index, 0).should exist
-      browser.strong(:xpath, "//strong[@id='descartes']").should exist
+      expect(browser.strong(:id, "descartes")).to exist
+      expect(browser.strong(:id, /descartes/)).to exist
+      expect(browser.strong(:text, "Dubito, ergo cogito, ergo sum.")).to exist
+      expect(browser.strong(:text, /Dubito, ergo cogito, ergo sum/)).to exist
+      expect(browser.strong(:class, "descartes")).to exist
+      expect(browser.strong(:class, /descartes/)).to exist
+      expect(browser.strong(:index, 0)).to exist
+      expect(browser.strong(:xpath, "//strong[@id='descartes']")).to exist
     end
 
     it "returns the first strong if given no args" do
-      browser.strong.should exist
+      expect(browser.strong).to exist
     end
 
     it "returns false if the element doesn't exist" do
-      browser.strong(:id, "no_such_id").should_not exist
-      browser.strong(:id, /no_such_id/).should_not exist
-      browser.strong(:text, "no_such_text").should_not exist
-      browser.strong(:text, /no_such_text/).should_not exist
-      browser.strong(:class, "no_such_class").should_not exist
-      browser.strong(:class, /no_such_class/).should_not exist
-      browser.strong(:index, 1337).should_not exist
-      browser.strong(:xpath, "//strong[@id='no_such_id']").should_not exist
+      expect(browser.strong(:id, "no_such_id")).to_not exist
+      expect(browser.strong(:id, /no_such_id/)).to_not exist
+      expect(browser.strong(:text, "no_such_text")).to_not exist
+      expect(browser.strong(:text, /no_such_text/)).to_not exist
+      expect(browser.strong(:class, "no_such_class")).to_not exist
+      expect(browser.strong(:class, /no_such_class/)).to_not exist
+      expect(browser.strong(:index, 1337)).to_not exist
+      expect(browser.strong(:xpath, "//strong[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.strong(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.strong(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.strong(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.strong(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Attribute methods
   describe "#class_name" do
     it "returns the class attribute" do
-      browser.strong(:index, 0).class_name.should == 'descartes'
+      expect(browser.strong(:index, 0).class_name).to eq 'descartes'
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.strong(:index, 1).class_name.should == ''
+      expect(browser.strong(:index, 1).class_name).to eq ''
     end
 
     it "raises UnknownObjectException if the element doesn't exist" do
-      lambda { browser.strong(:id, 'no_such_id').class_name }.should raise_error(UnknownObjectException)
+      expect{ browser.strong(:id, 'no_such_id').class_name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#id" do
     it "returns the id attribute" do
-      browser.strong(:index, 0).id.should == "descartes"
+      expect(browser.strong(:index, 0).id).to eq "descartes"
     end
 
     it "raises UnknownObjectException if the element doesn't exist" do
-      lambda { browser.strong(:id, "no_such_id").id }.should raise_error(UnknownObjectException)
-      lambda { browser.strong(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{ browser.strong(:id, "no_such_id").id }.to raise_error(UnknownObjectException)
+      expect{ browser.strong(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#text" do
     it "returns the text of the element" do
-      browser.strong(:index, 0).text.should == "Dubito, ergo cogito, ergo sum."
+      expect(browser.strong(:index, 0).text).to eq "Dubito, ergo cogito, ergo sum."
     end
 
     it "raises UnknownObjectException if the element doesn't exist" do
-      lambda { browser.strong(:id, 'no_such_id').text }.should raise_error( UnknownObjectException)
-      lambda { browser.strong(:xpath , "//strong[@id='no_such_id']").text }.should raise_error( UnknownObjectException)
+      expect{ browser.strong(:id, 'no_such_id').text }.to raise_error( UnknownObjectException)
+      expect{ browser.strong(:xpath , "//strong[@id='no_such_id']").text }.to raise_error( UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.strong(:index, 0).should respond_to(:class_name)
-      browser.strong(:index, 0).should respond_to(:id)
-      browser.strong(:index, 0).should respond_to(:text)
+      expect(browser.strong(:index, 0)).to respond_to(:class_name)
+      expect(browser.strong(:index, 0)).to respond_to(:id)
+      expect(browser.strong(:index, 0)).to respond_to(:text)
     end
   end
 

--- a/strongs_spec.rb
+++ b/strongs_spec.rb
@@ -10,20 +10,20 @@ describe "Strongs" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.strongs(:class => "descartes").to_a.should == [browser.strong(:class => "descartes")]
+        expect(browser.strongs(:class => "descartes").to_a).to eq [browser.strong(:class => "descartes")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the number of divs" do
-      browser.strongs.length.should == 2
+      expect(browser.strongs.length).to eq 2
     end
   end
 
   describe "#[]" do
     it "returns the div at the given index" do
-      browser.strongs[0].id.should == "descartes"
+      expect(browser.strongs[0].id).to eq "descartes"
     end
   end
 
@@ -33,13 +33,13 @@ describe "Strongs" do
 
       browser.strongs.each_with_index do |s, index|
         strong = browser.strong(:index, index)
-        s.id.should         == strong.id
-        s.class_name.should == strong.class_name
+        expect(s.id).to         eq strong.id
+        expect(s.class_name).to eq strong.class_name
 
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/table_nesting_spec.rb
+++ b/table_nesting_spec.rb
@@ -11,40 +11,40 @@ describe "Table" do
   not_compliant_on :internet_explorer do
     it "returns the correct number of rows under a table" do
       tables = browser.div(:id => "table-rows-test").tables(:id => /^tbl/)
-      tables.length.should > 0
+      expect(tables.length).to be > 0
 
       tables.each do |table|
         expected      = Integer(table.data_row_count)
         actual        = table.rows.length
         browser_count = Integer(table.data_browser_count)
 
-        actual.should eql(expected), "expected #{expected} rows, got #{actual} for table id=#{table.id}, browser reported: #{browser_count}"
+        expect(actual).to eql(expected), "expected #{expected} rows, got #{actual} for table id=#{table.id}, browser reported: #{browser_count}"
       end
     end
 
     it "returns the correct number of cells under a row" do
       rows = browser.div(:id => "row-cells-test").trs(:id => /^row/)
-      rows.length.should > 0
+      expect(rows.length).to be > 0
 
       rows.each do |row|
         expected      = Integer(row.data_cell_count)
         actual        = row.cells.length
         browser_count = Integer(row.data_browser_count)
 
-        actual.should eql(expected), "expected #{expected} cells, got #{actual} for row id=#{row.id}, browser reported: #{browser_count}"
+        expect(actual).to eql(expected), "expected #{expected} cells, got #{actual} for row id=#{row.id}, browser reported: #{browser_count}"
       end
     end
 
     it "returns the correct number of rows under a table section" do
       tbodies = browser.table(:id => "tbody-rows-test").tbodys(:id => /^body/)
-      tbodies.length.should > 0
+      expect(tbodies.length).to be > 0
 
       tbodies.each do |tbody|
         expected      = Integer(tbody.data_rows_count)
         actual        = tbody.rows.count
         browser_count = Integer(tbody.data_browser_count)
 
-        actual.should eql(expected), "expected #{expected} rows, got #{actual} for tbody id=#{tbody.id}, browser reported: #{browser_count}"
+        expect(actual).to eql(expected), "expected #{expected} rows, got #{actual} for tbody id=#{tbody.id}, browser reported: #{browser_count}"
       end
     end
   end

--- a/table_spec.rb
+++ b/table_spec.rb
@@ -10,47 +10,47 @@ describe "Table" do
   # Exists
   describe "#exists?" do
     it "returns true if the table exists" do
-      browser.table(:id, 'axis_example').should exist
-      browser.table(:id, /axis_example/).should exist
-      browser.table(:index, 0).should exist
-      browser.table(:xpath, "//table[@id='axis_example']").should exist
+      expect(browser.table(:id, 'axis_example')).to exist
+      expect(browser.table(:id, /axis_example/)).to exist
+      expect(browser.table(:index, 0)).to exist
+      expect(browser.table(:xpath, "//table[@id='axis_example']")).to exist
     end
 
     it "returns the first table if given no args" do
-      browser.table.should exist
+      expect(browser.table).to exist
     end
 
     it "returns false if the table does not exist" do
-      browser.table(:id, 'no_such_id').should_not exist
-      browser.table(:id, /no_such_id/).should_not exist
-      browser.table(:index, 1337).should_not exist
-      browser.table(:xpath, "//table[@id='no_such_id']").should_not exist
+      expect(browser.table(:id, 'no_such_id')).to_not exist
+      expect(browser.table(:id, /no_such_id/)).to_not exist
+      expect(browser.table(:index, 1337)).to_not exist
+      expect(browser.table(:xpath, "//table[@id='no_such_id']")).to_not exist
     end
 
     it "checks the tag name when locating by xpath" do
-      browser.table(:xpath, "//table//td").should_not exist
-      browser.table(:xpath, "//table").should exist
+      expect(browser.table(:xpath, "//table//td")).to_not exist
+      expect(browser.table(:xpath, "//table")).to exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.table(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.table(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.table(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.table(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Other
   describe "#strings" do
     it "returns a two-dimensional array representation of the table" do
-      browser.table(:id, 'inner').strings.should == [
+      expect(browser.table(:id, 'inner').strings).to eq [
         ["Table 2, Row 1, Cell 1",
          "Table 2, Row 1, Cell 2"]
       ]
 
       not_compliant_on :watir_classic do
-        browser.table(:id, 'outer').strings.should == [
+        expect(browser.table(:id, 'outer').strings).to eq [
           ["Table 1, Row 1, Cell 1", "Table 1, Row 1, Cell 2"],
           ["Table 1, Row 2, Cell 1", "Table 1, Row 2, Cell 2\nTable 2, Row 1, Cell 1 Table 2, Row 1, Cell 2"],
           ["Table 1, Row 3, Cell 1", "Table 1, Row 3, Cell 2"]
@@ -58,7 +58,7 @@ describe "Table" do
       end
 
       deviates_on :watir_classic do
-        browser.table(:id, 'outer').strings.should == [
+        expect(browser.table(:id, 'outer').strings).to eq [
           ["Table 1, Row 1, Cell 1", "Table 1, Row 1, Cell 2"],
           ["Table 1, Row 2, Cell 1", "Table 1, Row 2, Cell 2 Table 2, Row 1, Cell 1 Table 2, Row 1, Cell 2"],
           ["Table 1, Row 3, Cell 1", "Table 1, Row 3, Cell 2"]
@@ -69,7 +69,7 @@ describe "Table" do
 
   describe "#hashes" do
     it "returns an Array of Hashes for the common table usage" do
-      browser.table(:id => "axis_example").hashes.should == [
+      expect(browser.table(:id => "axis_example").hashes).to eq [
         { "" => "March 2008",     "Before income tax" => "",       "Income tax" => "",      "After income tax" => ""      },
         { "" => "Gregory House",  "Before income tax" => "5 934",  "Income tax" => "1 347", "After income tax" => "4 587" },
         { "" => "Hugh Laurie",    "Before income tax" => "6 300",  "Income tax" => "1 479", "After income tax" => "4 821" },
@@ -83,29 +83,29 @@ describe "Table" do
     it "raises an error if the table could not be parsed" do
       browser.goto(WatirSpec.url_for("uneven_table.html"))
 
-      lambda {
+      expect{
         browser.table.hashes
-      }.should raise_error("row at index 0 has 2 cells, expected 3")
+      }.to raise_error("row at index 0 has 2 cells, expected 3")
     end
   end
 
   describe "#click" do
     it "fires the table's onclick event" do
       browser.table(:id, 'inner').click
-      messages.should include('table')
+      expect(messages).to include('table')
     end
   end
 
   describe "#[]" do
     it "returns the nth child row" do
-      browser.table(:id, 'outer')[0].id.should == "outer_first"
-      browser.table(:id, 'inner')[0].id.should == "inner_first"
-      browser.table(:id, 'outer')[2].id.should == "outer_last"
+      expect(browser.table(:id, 'outer')[0].id).to eq "outer_first"
+      expect(browser.table(:id, 'inner')[0].id).to eq "inner_first"
+      expect(browser.table(:id, 'outer')[2].id).to eq "outer_last"
     end
 
     not_compliant_on :webdriver, :watir_classic do
       it "raises UnknownRowException if the index is out of bounds" do
-        lambda { browser.table(:id, 'outer')[1337] }.should raise_error(UnknownRowException)
+        expect{ browser.table(:id, 'outer')[1337] }.to raise_error(UnknownRowException)
       end
     end
   end
@@ -114,39 +114,39 @@ describe "Table" do
     let(:table) { browser.table(:id, 'outer') }
 
     it "finds rows belonging to this table" do
-      table.row(:id => "outer_last").should exist
-      table.row(:text => /Table 1, Row 1, Cell 1/).should exist
+      expect(table.row(:id => "outer_last")).to exist
+      expect(table.row(:text => /Table 1, Row 1, Cell 1/)).to exist
     end
 
     it "does not find rows from a nested table" do
-      table.row(:id => "inner_first").should_not exist
-      table.row(:text => /\ATable 2, Row 1, Cell 1 Table 2, Row 1, Cell 2\z/).should_not exist
+      expect(table.row(:id => "inner_first")).to_not exist
+      expect(table.row(:text => /\ATable 2, Row 1, Cell 1 Table 2, Row 1, Cell 2\z/)).to_not exist
     end
   end
 
   describe "#rows" do
     it "finds the correct number of rows (excluding nested tables)" do
-      browser.table(:id, 'inner').rows.length.should == 1
-      browser.table(:id, 'outer').rows.length.should == 3
+      expect(browser.table(:id, 'inner').rows.length).to eq 1
+      expect(browser.table(:id, 'outer').rows.length).to eq 3
     end
 
     it "finds rows matching the selector" do
       rows = browser.table(:id, 'outer').rows(:id => /first|last/)
 
-      rows.first.id.should == "outer_first"
-      rows.last.id.should  == "outer_last"
+      expect(rows.first.id).to eq "outer_first"
+      expect(rows.last.id).to  eq "outer_last"
     end
 
     it "does not find rows from a nested table" do
-      browser.table(:id, "outer").rows(:id => "t2_r1_c1").size.should == 0
+      expect(browser.table(:id, "outer").rows(:id => "t2_r1_c1").size).to eq 0
     end
   end
 
   describe "#tbody" do
     it "returns the correct instance of TableSection" do
       body = browser.table(:index, 0).tbody(:id, 'first')
-      body.should be_instance_of(TableSection)
-      body[0][0].text.should == "March 2008"
+      expect(body).to be_instance_of(TableSection)
+      expect(body[0][0].text).to eq "March 2008"
     end
   end
 
@@ -154,10 +154,10 @@ describe "Table" do
     it "returns the correct instance of TableSection" do
       bodies = browser.table(:index, 0).tbodys
 
-      bodies.should be_instance_of(TableSectionCollection)
+      expect(bodies).to be_instance_of(TableSectionCollection)
 
-      bodies[0].id.should == "first"
-      bodies[1].id.should == "second"
+      expect(bodies[0].id).to eq "first"
+      expect(bodies[1].id).to eq "second"
     end
   end
 

--- a/tables_spec.rb
+++ b/tables_spec.rb
@@ -10,22 +10,22 @@ describe "Tables" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.tables(:rules => "groups").to_a.should == [browser.table(:rules => "groups")]
+        expect(browser.tables(:rules => "groups").to_a).to eq [browser.table(:rules => "groups")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the number of tables" do
-      browser.tables.length.should == 4
+      expect(browser.tables.length).to eq 4
     end
   end
 
   describe "#[]" do
     it "returns the p at the given index" do
-      browser.tables[0].id.should == "axis_example"
-      browser.tables[1].id.should == "outer"
-      browser.tables[2].id.should == "inner"
+      expect(browser.tables[0].id).to eq "axis_example"
+      expect(browser.tables[1].id).to eq "outer"
+      expect(browser.tables[2].id).to eq "inner"
     end
   end
 
@@ -34,11 +34,11 @@ describe "Tables" do
       count = 0
 
       browser.tables.each_with_index do |t, index|
-        t.id.should == browser.table(:index, index).id
+        expect(t.id).to eq browser.table(:index, index).id
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/tbody_spec.rb
+++ b/tbody_spec.rb
@@ -9,59 +9,59 @@ describe "TableBody" do
 
   describe "#exists?" do
     it "returns true if the table body exists (page context)" do
-      browser.tbody(:id, 'first').should exist
-      browser.tbody(:id, /first/).should exist
-      browser.tbody(:index, 0).should exist
-      browser.tbody(:xpath, "//tbody[@id='first']").should exist
+      expect(browser.tbody(:id, 'first')).to exist
+      expect(browser.tbody(:id, /first/)).to exist
+      expect(browser.tbody(:index, 0)).to exist
+      expect(browser.tbody(:xpath, "//tbody[@id='first']")).to exist
     end
 
     it "returns true if the table body exists (table context)" do
-      browser.table(:index, 0).tbody(:id, 'first').should exist
-      browser.table(:index, 0).tbody(:id, /first/).should exist
-      browser.table(:index, 0).tbody(:index, 1).should exist
-      browser.table(:index, 0).tbody(:xpath, "//tbody[@id='first']").should exist
+      expect(browser.table(:index, 0).tbody(:id, 'first')).to exist
+      expect(browser.table(:index, 0).tbody(:id, /first/)).to exist
+      expect(browser.table(:index, 0).tbody(:index, 1)).to exist
+      expect(browser.table(:index, 0).tbody(:xpath, "//tbody[@id='first']")).to exist
     end
 
     it "returns the first table body if given no args" do
-      browser.table.tbody.should exist
+      expect(browser.table.tbody).to exist
     end
 
     it "returns false if the table body doesn't exist (page context)" do
-      browser.tbody(:id, 'no_such_id').should_not exist
-      browser.tbody(:id, /no_such_id/).should_not exist
-      browser.tbody(:index, 1337).should_not exist
-      browser.tbody(:xpath, "//tbody[@id='no_such_id']").should_not exist
+      expect(browser.tbody(:id, 'no_such_id')).to_not exist
+      expect(browser.tbody(:id, /no_such_id/)).to_not exist
+      expect(browser.tbody(:index, 1337)).to_not exist
+      expect(browser.tbody(:xpath, "//tbody[@id='no_such_id']")).to_not exist
     end
 
     it "returns false if the table body doesn't exist (table context)" do
-      browser.table(:index, 0).tbody(:id, 'no_such_id').should_not exist
-      browser.table(:index, 0).tbody(:id, /no_such_id/).should_not exist
-      browser.table(:index, 0).tbody(:index, 1337).should_not exist
-      browser.table(:index, 0).tbody(:xpath, "//tbody[@id='no_such_id']").should_not exist
+      expect(browser.table(:index, 0).tbody(:id, 'no_such_id')).to_not exist
+      expect(browser.table(:index, 0).tbody(:id, /no_such_id/)).to_not exist
+      expect(browser.table(:index, 0).tbody(:index, 1337)).to_not exist
+      expect(browser.table(:index, 0).tbody(:xpath, "//tbody[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.tbody(:id, 3.14).exists? }.should raise_error(TypeError)
-      lambda { browser.table(:index, 0).tbody(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.tbody(:id, 3.14).exists? }.to raise_error(TypeError)
+      expect{ browser.table(:index, 0).tbody(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.tbody(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
-      lambda { browser.table(:index, 0).tbody(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.tbody(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.table(:index, 0).tbody(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   describe "#[]" do
     it "returns the row at the given index (page context)" do
-      browser.tbody(:id, 'first')[0].text.should == 'March 2008'
-      browser.tbody(:id, 'first')[1][0].text.should == 'Gregory House'
-      browser.tbody(:id, 'first')[2][0].text.should == 'Hugh Laurie'
+      expect(browser.tbody(:id, 'first')[0].text).to eq 'March 2008'
+      expect(browser.tbody(:id, 'first')[1][0].text).to eq 'Gregory House'
+      expect(browser.tbody(:id, 'first')[2][0].text).to eq 'Hugh Laurie'
     end
 
     it "returns the row at the given index (table context)" do
-      browser.table(:index, 0).tbody(:id, 'first')[0].text.should == 'March 2008'
-      browser.table(:index, 0).tbody(:id, 'first')[1][0].text.should == 'Gregory House'
-      browser.table(:index, 0).tbody(:id, 'first')[2][0].text.should == 'Hugh Laurie'
+      expect(browser.table(:index, 0).tbody(:id, 'first')[0].text).to eq 'March 2008'
+      expect(browser.table(:index, 0).tbody(:id, 'first')[1][0].text).to eq 'Gregory House'
+      expect(browser.table(:index, 0).tbody(:id, 'first')[2][0].text).to eq 'Hugh Laurie'
     end
   end
 
@@ -69,8 +69,8 @@ describe "TableBody" do
     it "finds the first row matching the selector" do
       row = browser.tbody(:id, 'first').row(:id => "gregory")
 
-      row.tag_name.should == "tr"
-      row.id.should == "gregory"
+      expect(row.tag_name).to eq "tr"
+      expect(row.id).to eq "gregory"
     end
   end
 
@@ -78,16 +78,16 @@ describe "TableBody" do
     it "finds rows matching the selector" do
       rows = browser.tbody(:id, 'first').rows(:id => /h$/)
 
-      rows.size.should == 2
+      expect(rows.size).to eq 2
 
-      rows.first.id.should == "march"
-      rows.last.id.should == "hugh"
+      expect(rows.first.id).to eq "march"
+      expect(rows.last.id).to eq "hugh"
     end
   end
 
   describe "#strings" do
     it "returns the text of child cells" do
-      browser.tbody(:id, 'first').strings.should == [
+      expect(browser.tbody(:id, 'first').strings).to eq [
         ["March 2008", "", "", ""],
         ["Gregory House", "5 934", "1 347", "4 587"],
         ["Hugh Laurie", "6 300", "1 479", "4 821"]

--- a/tbodys_spec.rb
+++ b/tbodys_spec.rb
@@ -10,28 +10,28 @@ describe "TableBodies" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.tbodys(:id => "first").to_a.should == [browser.tbody(:id => "first")]
+        expect(browser.tbodys(:id => "first").to_a).to eq [browser.tbody(:id => "first")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the correct number of table bodies (page context)" do
-      browser.tbodys.length.should == 5
+      expect(browser.tbodys.length).to eq 5
     end
 
     it "returns the correct number of table bodies (table context)" do
-      browser.table(:index, 0).tbodys.length.should == 2
+      expect(browser.table(:index, 0).tbodys.length).to eq 2
     end
   end
 
   describe "#[]" do
     it "returns the row at the given index (page context)" do
-      browser.tbodys[0].id.should == "first"
+      expect(browser.tbodys[0].id).to eq "first"
     end
 
     it "returns the row at the given index (table context)" do
-      browser.table(:index, 0).tbodys[0].id.should == "first"
+      expect(browser.table(:index, 0).tbodys[0].id).to eq "first"
     end
   end
 
@@ -40,12 +40,12 @@ describe "TableBodies" do
       count = 0
 
       browser.tbodys.each_with_index do |body, index|
-        body.id.should == browser.tbody(:index, index).id
+        expect(body.id).to eq browser.tbody(:index, index).id
 
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
 
     it "iterates through table bodies correctly (table context)" do
@@ -53,12 +53,12 @@ describe "TableBodies" do
       count = 0
 
       table.tbodys.each_with_index do |body, index|
-        body.id.should == table.tbody(:index, index).id
+        expect(body.id).to eq table.tbody(:index, index).id
 
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/td_spec.rb
+++ b/td_spec.rb
@@ -10,62 +10,62 @@ describe "TableCell" do
   # Exists
   describe "#exists?" do
     it "returns true when the table cell exists" do
-      browser.td(:id, 't1_r2_c1').should exist
-      browser.td(:id, /t1_r2_c1/).should exist
-      browser.td(:text, 'Table 1, Row 3, Cell 1').should exist
-      browser.td(:text, /Table 1/).should exist
-      browser.td(:index, 0).should exist
-      browser.td(:xpath, "//td[@id='t1_r2_c1']").should exist
+      expect(browser.td(:id, 't1_r2_c1')).to exist
+      expect(browser.td(:id, /t1_r2_c1/)).to exist
+      expect(browser.td(:text, 'Table 1, Row 3, Cell 1')).to exist
+      expect(browser.td(:text, /Table 1/)).to exist
+      expect(browser.td(:index, 0)).to exist
+      expect(browser.td(:xpath, "//td[@id='t1_r2_c1']")).to exist
     end
 
     it "returns the first cell if given no args" do
-      browser.td.should exist
+      expect(browser.td).to exist
     end
 
     it "returns false when the table cell does not exist" do
-      browser.td(:id, 'no_such_id').should_not exist
-      browser.td(:id, /no_such_id/).should_not exist
-      browser.td(:text, 'no_such_text').should_not exist
-      browser.td(:text, /no_such_text/).should_not exist
-      browser.td(:index, 1337).should_not exist
-      browser.td(:xpath, "//td[@id='no_such_id']").should_not exist
+      expect(browser.td(:id, 'no_such_id')).to_not exist
+      expect(browser.td(:id, /no_such_id/)).to_not exist
+      expect(browser.td(:text, 'no_such_text')).to_not exist
+      expect(browser.td(:text, /no_such_text/)).to_not exist
+      expect(browser.td(:index, 1337)).to_not exist
+      expect(browser.td(:xpath, "//td[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.td(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.td(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.td(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.td(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   describe "#click" do
     it "fires the table's onclick event" do
       browser.td(:id, 't2_r1_c1').click
-      messages.should include('td')
+      expect(messages).to include('td')
     end
   end
 
   # Attribute methods
   describe "#text" do
     it "returns the text inside the table cell" do
-      browser.td(:id, 't1_r2_c1').text.should == 'Table 1, Row 2, Cell 1'
-      browser.td(:id, 't2_r1_c1').text.should == 'Table 2, Row 1, Cell 1'
+      expect(browser.td(:id, 't1_r2_c1').text).to eq 'Table 1, Row 2, Cell 1'
+      expect(browser.td(:id, 't2_r1_c1').text).to eq 'Table 2, Row 1, Cell 1'
     end
   end
 
   describe "#colspan" do
     it "gets the colspan attribute" do
-      browser.td(:id, 'colspan_2').colspan.should == 2
-      browser.td(:id, 'no_colspan').colspan.should == 1
+      expect(browser.td(:id, 'colspan_2').colspan).to eq 2
+      expect(browser.td(:id, 'no_colspan').colspan).to eq 1
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.td(:index, 0).should respond_to(:text)
-      browser.td(:index, 0).should respond_to(:colspan)
+      expect(browser.td(:index, 0)).to respond_to(:text)
+      expect(browser.td(:index, 0)).to respond_to(:colspan)
     end
   end
 

--- a/tds_spec.rb
+++ b/tds_spec.rb
@@ -10,23 +10,23 @@ describe "TableCells" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.tds(:headers => "before_tax").to_a.should == [browser.td(:headers => "before_tax")]
+        expect(browser.tds(:headers => "before_tax").to_a).to eq [browser.td(:headers => "before_tax")]
       end
     end
   end
 
   #  describe "#length" do
   #    it "returns the number of cells" do
-  #      browser.table(:id, 'outer').cells.length.should == 6
-  #      browser.table(:id, 'inner').cells.length.should == 2
+  #      browser.table(:id, 'outer').cells.length.to eq 6
+  #      browser.table(:id, 'inner').cells.length.to eq 2
   #    end
   #  end
   #
   #  describe "#[]" do
   #    it "returns the row at the given index" do
-  #      browser.table(:id, 'outer').cells[0].text.should == "Table 1, Row 1, Cell 1"
-  #      browser.table(:id, 'inner').cells[0].text.should == "Table 2, Row 1, Cell 1"
-  #      browser.table(:id, 'outer').cells[6].text.should == "Table 1, Row 3, Cell 2"
+  #      browser.table(:id, 'outer').cells[0].text.to eq "Table 1, Row 1, Cell 1"
+  #      browser.table(:id, 'inner').cells[0].text.to eq "Table 2, Row 1, Cell 1"
+  #      browser.table(:id, 'outer').cells[6].text.to eq "Table 1, Row 3, Cell 2"
   #    end
   #  end
 
@@ -35,11 +35,11 @@ describe "TableCells" do
       count = 0
 
       browser.tds.each_with_index do |c, index|
-        c.id.should == browser.td(:index, index).id
+        expect(c.id).to eq browser.td(:index, index).id
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
 
     it "iterates through cells inside a table" do
@@ -47,7 +47,7 @@ describe "TableCells" do
 
       inner_table = browser.table(:id, 'inner')
       inner_table.tds.each_with_index do |c, index|
-        c.id.should == inner_table.td(:index, index).id
+        expect(c.id).to eq inner_table.td(:index, index).id
         count += 1
       end
     end

--- a/text_field_spec.rb
+++ b/text_field_spec.rb
@@ -10,187 +10,187 @@ describe "TextField" do
   # Exists method
   describe "#exists?" do
     it "returns true if the element exists" do
-      browser.text_field(:id, 'new_user_email').should exist
-      browser.text_field(:id, /new_user_email/).should exist
-      browser.text_field(:name, 'new_user_email').should exist
-      browser.text_field(:name, /new_user_email/).should exist
-      browser.text_field(:value, 'Developer').should exist
-      browser.text_field(:value, /Developer/).should exist
-      browser.text_field(:text, 'Developer').should exist
-      browser.text_field(:text, /Developer/).should exist
-      browser.text_field(:class, 'name').should exist
-      browser.text_field(:class, /name/).should exist
-      browser.text_field(:index, 0).should exist
-      browser.text_field(:xpath, "//input[@id='new_user_email']").should exist
-      browser.text_field(:label, "First name").should exist
-      browser.text_field(:label, /(Last|First) name/).should exist
-      browser.text_field(:label, 'Without for').should exist
-      browser.text_field(:label, /Without for/).should exist
+      expect(browser.text_field(:id, 'new_user_email')).to exist
+      expect(browser.text_field(:id, /new_user_email/)).to exist
+      expect(browser.text_field(:name, 'new_user_email')).to exist
+      expect(browser.text_field(:name, /new_user_email/)).to exist
+      expect(browser.text_field(:value, 'Developer')).to exist
+      expect(browser.text_field(:value, /Developer/)).to exist
+      expect(browser.text_field(:text, 'Developer')).to exist
+      expect(browser.text_field(:text, /Developer/)).to exist
+      expect(browser.text_field(:class, 'name')).to exist
+      expect(browser.text_field(:class, /name/)).to exist
+      expect(browser.text_field(:index, 0)).to exist
+      expect(browser.text_field(:xpath, "//input[@id='new_user_email']")).to exist
+      expect(browser.text_field(:label, "First name")).to exist
+      expect(browser.text_field(:label, /(Last|First) name/)).to exist
+      expect(browser.text_field(:label, 'Without for')).to exist
+      expect(browser.text_field(:label, /Without for/)).to exist
     end
 
     it "returns the first text field if given no args" do
-      browser.text_field.should exist
+      expect(browser.text_field).to exist
     end
 
     it "returns true if the element exists (no type attribute)" do
-      browser.text_field(:id, 'new_user_first_name').should exist
+      expect(browser.text_field(:id, 'new_user_first_name')).to exist
     end
 
     it "returns true if the element exists (invalid type attribute)" do
-      browser.text_field(:id, 'new_user_last_name').should exist
+      expect(browser.text_field(:id, 'new_user_last_name')).to exist
     end
 
     it "returns true for element with upper case type" do
-      browser.text_field(:id, "new_user_email_confirm").should exist
+      expect(browser.text_field(:id, "new_user_email_confirm")).to exist
     end
 
     it "returns true for element with unknown type attribute" do
-      browser.text_field(:id, "unknown_text_field").should exist
+      expect(browser.text_field(:id, "unknown_text_field")).to exist
     end
 
     it "returns false if the element does not exist" do
-      browser.text_field(:id, 'no_such_id').should_not exist
-      browser.text_field(:id, /no_such_id/).should_not exist
-      browser.text_field(:name, 'no_such_name').should_not exist
-      browser.text_field(:name, /no_such_name/).should_not exist
-      browser.text_field(:value, 'no_such_value').should_not exist
-      browser.text_field(:value, /no_such_value/).should_not exist
-      browser.text_field(:text, 'no_such_text').should_not exist
-      browser.text_field(:text, /no_such_text/).should_not exist
-      browser.text_field(:class, 'no_such_class').should_not exist
-      browser.text_field(:class, /no_such_class/).should_not exist
-      browser.text_field(:index, 1337).should_not exist
-      browser.text_field(:xpath, "//input[@id='no_such_id']").should_not exist
-      browser.text_field(:label, "bad label").should_not exist
-      browser.text_field(:label, /bad label/).should_not exist
+      expect(browser.text_field(:id, 'no_such_id')).to_not exist
+      expect(browser.text_field(:id, /no_such_id/)).to_not exist
+      expect(browser.text_field(:name, 'no_such_name')).to_not exist
+      expect(browser.text_field(:name, /no_such_name/)).to_not exist
+      expect(browser.text_field(:value, 'no_such_value')).to_not exist
+      expect(browser.text_field(:value, /no_such_value/)).to_not exist
+      expect(browser.text_field(:text, 'no_such_text')).to_not exist
+      expect(browser.text_field(:text, /no_such_text/)).to_not exist
+      expect(browser.text_field(:class, 'no_such_class')).to_not exist
+      expect(browser.text_field(:class, /no_such_class/)).to_not exist
+      expect(browser.text_field(:index, 1337)).to_not exist
+      expect(browser.text_field(:xpath, "//input[@id='no_such_id']")).to_not exist
+      expect(browser.text_field(:label, "bad label")).to_not exist
+      expect(browser.text_field(:label, /bad label/)).to_not exist
 
       # input type='hidden' should not be found by #text_field
-      browser.text_field(:id, "new_user_interests_dolls").should_not exist
+      expect(browser.text_field(:id, "new_user_interests_dolls")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.text_field(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.text_field(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.text_field(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.text_field(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Attribute methods
   describe "#id" do
     it "returns the id attribute if the text field exists" do
-      browser.text_field(:index, 4).id.should == "new_user_occupation"
+      expect(browser.text_field(:index, 4).id).to eq "new_user_occupation"
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      lambda { browser.text_field(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{ browser.text_field(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#name" do
     it "returns the name attribute if the text field exists" do
-      browser.text_field(:index, 3).name.should == "new_user_email_confirm"
+      expect(browser.text_field(:index, 3).name).to eq "new_user_email_confirm"
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      lambda { browser.text_field(:index, 1337).name }.should raise_error(UnknownObjectException)
+      expect{ browser.text_field(:index, 1337).name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#title" do
     it "returns the title attribute if the text field exists" do
-      browser.text_field(:id, "new_user_code").title.should == "Your personal code"
+      expect(browser.text_field(:id, "new_user_code").title).to eq "Your personal code"
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      lambda { browser.text_field(:index, 1337).title }.should raise_error(UnknownObjectException)
+      expect{ browser.text_field(:index, 1337).title }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#type" do
     it "returns the type attribute if the text field exists" do
-      browser.text_field(:index, 3).type.should == "text"
+      expect(browser.text_field(:index, 3).type).to eq "text"
     end
 
     it "returns 'text' if the type attribute is invalid" do
-      browser.text_field(:id, 'new_user_last_name').type.should == "text"
+      expect(browser.text_field(:id, 'new_user_last_name').type).to eq "text"
     end
 
     it "returns 'text' if the type attribute does not exist" do
-      browser.text_field(:id, 'new_user_first_name').type.should == "text"
+      expect(browser.text_field(:id, 'new_user_first_name').type).to eq "text"
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      lambda { browser.text_field(:index, 1337).type }.should raise_error(UnknownObjectException)
+      expect{ browser.text_field(:index, 1337).type }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#value" do
     it "returns the value attribute if the text field exists" do
-      browser.text_field(:name, "new_user_occupation").value.should == "Developer"
-      browser.text_field(:index, 4).value.should == "Developer"
-      browser.text_field(:name, /new_user_occupation/i).value.should == "Developer"
+      expect(browser.text_field(:name, "new_user_occupation").value).to eq "Developer"
+      expect(browser.text_field(:index, 4).value).to eq "Developer"
+      expect(browser.text_field(:name, /new_user_occupation/i).value).to eq "Developer"
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      lambda { browser.text_field(:index, 1337).value }.should raise_error(UnknownObjectException)
+      expect{ browser.text_field(:index, 1337).value }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.text_field(:index, 0).should respond_to(:class_name)
-      browser.text_field(:index, 0).should respond_to(:id)
-      browser.text_field(:index, 0).should respond_to(:name)
-      browser.text_field(:index, 0).should respond_to(:title)
-      browser.text_field(:index, 0).should respond_to(:type)
-      browser.text_field(:index, 0).should respond_to(:value)
+      expect(browser.text_field(:index, 0)).to respond_to(:class_name)
+      expect(browser.text_field(:index, 0)).to respond_to(:id)
+      expect(browser.text_field(:index, 0)).to respond_to(:name)
+      expect(browser.text_field(:index, 0)).to respond_to(:title)
+      expect(browser.text_field(:index, 0)).to respond_to(:type)
+      expect(browser.text_field(:index, 0)).to respond_to(:value)
     end
   end
 
   # Access methods
   describe "#enabled?" do
     it "returns true for enabled text fields" do
-      browser.text_field(:name, "new_user_occupation").should be_enabled
-      browser.text_field(:id, "new_user_email").should be_enabled
+      expect(browser.text_field(:name, "new_user_occupation")).to be_enabled
+      expect(browser.text_field(:id, "new_user_email")).to be_enabled
     end
 
     it "returns false for disabled text fields" do
-      browser.text_field(:name, "new_user_species").should_not be_enabled
+      expect(browser.text_field(:name, "new_user_species")).to_not be_enabled
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      lambda { browser.text_field(:id, "no_such_id").enabled? }.should raise_error(UnknownObjectException)
+      expect{ browser.text_field(:id, "no_such_id").enabled? }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#disabled?" do
     it "returns true if the text field is disabled" do
-      browser.text_field(:id, 'new_user_species').should be_disabled
+      expect(browser.text_field(:id, 'new_user_species')).to be_disabled
     end
 
     it "returns false if the text field is enabled" do
-      browser.text_field(:index, 0).should_not be_disabled
+      expect(browser.text_field(:index, 0)).to_not be_disabled
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      lambda { browser.text_field(:index, 1337).disabled? }.should raise_error(UnknownObjectException)
+      expect{ browser.text_field(:index, 1337).disabled? }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#readonly?" do
     it "returns true for read-only text fields" do
-      browser.text_field(:name, "new_user_code").should be_readonly
-      browser.text_field(:id, "new_user_code").should be_readonly
+      expect(browser.text_field(:name, "new_user_code")).to be_readonly
+      expect(browser.text_field(:id, "new_user_code")).to be_readonly
     end
 
     it "returns false for writable text fields" do
-      browser.text_field(:name, "new_user_email").should_not be_readonly
+      expect(browser.text_field(:name, "new_user_email")).to_not be_readonly
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      lambda { browser.text_field(:id, 'no_such_id').readonly? }.should raise_error(UnknownObjectException)
+      expect{ browser.text_field(:id, 'no_such_id').readonly? }.to raise_error(UnknownObjectException)
     end
   end
 
@@ -198,94 +198,94 @@ describe "TextField" do
   describe "#append" do
     it "appends the text to the text field" do
       browser.text_field(:name, "new_user_occupation").append(" Append This")
-      browser.text_field(:name, "new_user_occupation").value.should == "Developer Append This"
+      expect(browser.text_field(:name, "new_user_occupation").value).to eq "Developer Append This"
     end
 
     it "appends multi-byte characters" do
       browser.text_field(:name, "new_user_occupation").append(" ĳĳ")
-      browser.text_field(:name, "new_user_occupation").value.should == "Developer ĳĳ"
+      expect(browser.text_field(:name, "new_user_occupation").value).to eq "Developer ĳĳ"
     end
 
     it "raises ObjectReadOnlyException if the object is read only" do
-      lambda { browser.text_field(:id, "new_user_code").append("Append This") }.should raise_error(ObjectReadOnlyException)
+      expect{ browser.text_field(:id, "new_user_code").append("Append This") }.to raise_error(ObjectReadOnlyException)
     end
 
     it "raises ObjectDisabledException if the object is disabled" do
-      lambda { browser.text_field(:name, "new_user_species").append("Append This") }.should raise_error(ObjectDisabledException)
+      expect{ browser.text_field(:name, "new_user_species").append("Append This") }.to raise_error(ObjectDisabledException)
     end
 
     it "raises UnknownObjectException if the object doesn't exist" do
-      lambda { browser.text_field(:name, "no_such_name").append("Append This") }.should raise_error(UnknownObjectException)
+      expect{ browser.text_field(:name, "no_such_name").append("Append This") }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#clear" do
     it "removes all text from the text field" do
       browser.text_field(:name, "new_user_occupation").clear
-      browser.text_field(:name, "new_user_occupation").value.should be_empty
+      expect(browser.text_field(:name, "new_user_occupation").value).to be_empty
       browser.text_field(:id, "delete_user_comment").clear
-      browser.text_field(:id, "delete_user_comment").value.should be_empty
+      expect(browser.text_field(:id, "delete_user_comment").value).to be_empty
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      lambda { browser.text_field(:id, "no_such_id").clear }.should raise_error(UnknownObjectException)
+      expect{ browser.text_field(:id, "no_such_id").clear }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#value=" do
     it "sets the value of the element" do
       browser.text_field(:id, 'new_user_email').value = 'Hello Cruel World'
-      browser.text_field(:id, "new_user_email").value.should == 'Hello Cruel World'
+      expect(browser.text_field(:id, "new_user_email").value).to eq 'Hello Cruel World'
     end
 
     it "is able to set multi-byte characters" do
       browser.text_field(:name, "new_user_occupation").value = "ĳĳ"
-      browser.text_field(:name, "new_user_occupation").value.should == "ĳĳ"
+      expect(browser.text_field(:name, "new_user_occupation").value).to eq "ĳĳ"
     end
 
     it "sets the value of a textarea element" do
       browser.text_field(:id, 'delete_user_comment').value = 'Hello Cruel World'
-      browser.text_field(:id, "delete_user_comment").value.should == 'Hello Cruel World'
+      expect(browser.text_field(:id, "delete_user_comment").value).to eq 'Hello Cruel World'
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      lambda { browser.text_field(:name, "no_such_name").value = 'yo' }.should raise_error(UnknownObjectException)
+      expect{ browser.text_field(:name, "no_such_name").value = 'yo' }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#set" do
     it "sets the value of the element" do
       browser.text_field(:id, 'new_user_email').set('Bye Cruel World')
-      browser.text_field(:id, "new_user_email").value.should == 'Bye Cruel World'
+      expect(browser.text_field(:id, "new_user_email").value).to eq 'Bye Cruel World'
     end
 
     it "sets the value of a textarea element" do
       browser.text_field(:id, 'delete_user_comment').set('Hello Cruel World')
-      browser.text_field(:id, "delete_user_comment").value.should == 'Hello Cruel World'
+      expect(browser.text_field(:id, "delete_user_comment").value).to eq 'Hello Cruel World'
     end
 
     it "fires events" do
       browser.text_field(:id, "new_user_username").set("Hello World")
-      browser.span(:id, "current_length").text.should == "11"
+      expect(browser.span(:id, "current_length").text).to eq "11"
     end
 
     it "sets the value of a password field" do
       browser.text_field(:name, 'new_user_password').set('secret')
-      browser.text_field(:name, 'new_user_password').value.should == 'secret'
+      expect(browser.text_field(:name, 'new_user_password').value).to eq 'secret'
     end
 
     it "sets the value when accessed through the enclosing Form" do
       browser.form(:id, 'new_user').text_field(:name, 'new_user_password').set('secret')
-      browser.form(:id, 'new_user').text_field(:name, 'new_user_password').value.should == 'secret'
+      expect(browser.form(:id, 'new_user').text_field(:name, 'new_user_password').value).to eq 'secret'
     end
 
     it "is able to set multi-byte characters" do
       browser.text_field(:name, "new_user_occupation").set("ĳĳ")
-      browser.text_field(:name, "new_user_occupation").value.should == "ĳĳ"
+      expect(browser.text_field(:name, "new_user_occupation").value).to eq "ĳĳ"
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      lambda { browser.text_field(:id, "no_such_id").set('secret') }.should raise_error(UnknownObjectException)
+      expect{ browser.text_field(:id, "no_such_id").set('secret') }.to raise_error(UnknownObjectException)
     end
   end
 end

--- a/text_fields_spec.rb
+++ b/text_fields_spec.rb
@@ -10,22 +10,22 @@ describe "TextFields" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.text_fields(:name => "new_user_email").to_a.should == [browser.text_field(:name => "new_user_email")]
+        expect(browser.text_fields(:name => "new_user_email").to_a).to eq [browser.text_field(:name => "new_user_email")]
       end
     end
   end
 
   describe "#length" do
     it "returns the number of text fields" do
-      browser.text_fields.length.should == 14
+      expect(browser.text_fields.length).to eq 14
     end
   end
 
   describe "#[]" do
     it "returns the text field at the given index" do
-      browser.text_fields[0].id.should == "new_user_first_name"
-      browser.text_fields[1].id.should == "new_user_last_name"
-      browser.text_fields[2].id.should == "new_user_email"
+      expect(browser.text_fields[0].id).to eq "new_user_first_name"
+      expect(browser.text_fields[1].id).to eq "new_user_last_name"
+      expect(browser.text_fields[2].id).to eq "new_user_email"
     end
   end
 
@@ -34,14 +34,14 @@ describe "TextFields" do
       count = 0
 
       browser.text_fields.each_with_index do |r, index|
-        r.name.should == browser.text_field(:index, index).name
-        r.id.should ==  browser.text_field(:index, index).id
-        r.value.should == browser.text_field(:index, index).value
+        expect(r.name).to eq browser.text_field(:index, index).name
+        expect(r.id).to eq browser.text_field(:index, index).id
+        expect(r.value).to eq browser.text_field(:index, index).value
 
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 end

--- a/textarea_spec.rb
+++ b/textarea_spec.rb
@@ -9,18 +9,18 @@ describe "TextArea" do
 
   it 'can set a value' do
     textarea.set 'foo'
-    textarea.value.should == 'foo'
+    expect(textarea.value).to eq 'foo'
   end
 
   it 'can clear a value' do
     textarea.set 'foo'
     textarea.clear
-    textarea.value.should == ''
+    expect(textarea.value).to eq ''
   end
 
   it 'locates textarea by value' do
     browser.textarea.set 'foo'
-    browser.textarea(:value, /foo/).should exist
-    browser.textarea(:value, 'foo').should exist
+    expect(browser.textarea(:value, /foo/)).to exist
+    expect(browser.textarea(:value, 'foo')).to exist
   end
 end

--- a/textareas_spec.rb
+++ b/textareas_spec.rb
@@ -12,14 +12,14 @@ describe 'TextArea' do
     end
 
     it 'finds textareas by string' do
-      browser.textareas(:value, 'foo1').map(&:id).should == [browser.textarea(index: 0).id]
-      browser.textareas(:value, 'foo2').map(&:id).should == [browser.textarea(index: 1).id]
+      expect(browser.textareas(:value, 'foo1').map(&:id)).to eq [browser.textarea(index: 0).id]
+      expect(browser.textareas(:value, 'foo2').map(&:id)).to eq [browser.textarea(index: 1).id]
     end
 
 
     it 'finds textareas by regexp' do
-      browser.textareas(:value, /foo/)[0].id.should == browser.textarea(index: 0).id
-      browser.textareas(:value, /foo/)[1].id.should == browser.textarea(index: 1).id
+      expect(browser.textareas(:value, /foo/)[0].id).to eq browser.textarea(index: 0).id
+      expect(browser.textareas(:value, /foo/)[1].id).to eq browser.textarea(index: 1).id
     end
   end
 end

--- a/tfoot_spec.rb
+++ b/tfoot_spec.rb
@@ -8,59 +8,59 @@ describe "TableFooter" do
 
   describe "#exists?" do
     it "returns true if the table tfoot exists (page context)" do
-      browser.tfoot(:id, 'tax_totals').should exist
-      browser.tfoot(:id, /tax_totals/).should exist
-      browser.tfoot(:index, 0).should exist
-      browser.tfoot(:xpath, "//tfoot[@id='tax_totals']").should exist
+      expect(browser.tfoot(:id, 'tax_totals')).to exist
+      expect(browser.tfoot(:id, /tax_totals/)).to exist
+      expect(browser.tfoot(:index, 0)).to exist
+      expect(browser.tfoot(:xpath, "//tfoot[@id='tax_totals']")).to exist
     end
 
     it "returns true if the table tfoot exists (table context)" do
-      browser.table(:index, 0).tfoot(:id, 'tax_totals').should exist
-      browser.table(:index, 0).tfoot(:id, /tax_totals/).should exist
-      browser.table(:index, 0).tfoot(:index, 0).should exist
-      browser.table(:index, 0).tfoot(:xpath, "//tfoot[@id='tax_totals']").should exist
+      expect(browser.table(:index, 0).tfoot(:id, 'tax_totals')).to exist
+      expect(browser.table(:index, 0).tfoot(:id, /tax_totals/)).to exist
+      expect(browser.table(:index, 0).tfoot(:index, 0)).to exist
+      expect(browser.table(:index, 0).tfoot(:xpath, "//tfoot[@id='tax_totals']")).to exist
     end
 
     it "returns the first tfoot if given no args" do
-      browser.tfoot.should exist
+      expect(browser.tfoot).to exist
     end
 
     it "returns false if the table tfoot doesn't exist (page context)" do
-      browser.tfoot(:id, 'no_such_id').should_not exist
-      browser.tfoot(:id, /no_such_id/).should_not exist
-      browser.tfoot(:index, 1337).should_not exist
-      browser.tfoot(:xpath, "//tfoot[@id='no_such_id']").should_not exist
+      expect(browser.tfoot(:id, 'no_such_id')).to_not exist
+      expect(browser.tfoot(:id, /no_such_id/)).to_not exist
+      expect(browser.tfoot(:index, 1337)).to_not exist
+      expect(browser.tfoot(:xpath, "//tfoot[@id='no_such_id']")).to_not exist
     end
 
     it "returns false if the table tfoot doesn't exist (table context)" do
-      browser.table(:index, 0).tfoot(:id, 'no_such_id').should_not exist
-      browser.table(:index, 0).tfoot(:id, /no_such_id/).should_not exist
-      browser.table(:index, 0).tfoot(:index, 1337).should_not exist
-      browser.table(:index, 0).tfoot(:xpath, "//tfoot[@id='no_such_id']").should_not exist
+      expect(browser.table(:index, 0).tfoot(:id, 'no_such_id')).to_not exist
+      expect(browser.table(:index, 0).tfoot(:id, /no_such_id/)).to_not exist
+      expect(browser.table(:index, 0).tfoot(:index, 1337)).to_not exist
+      expect(browser.table(:index, 0).tfoot(:xpath, "//tfoot[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.tfoot(:id, 3.14).exists? }.should raise_error(TypeError)
-      lambda { browser.table(:index, 0).tfoot(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.tfoot(:id, 3.14).exists? }.to raise_error(TypeError)
+      expect{ browser.table(:index, 0).tfoot(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.tfoot(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
-      lambda { browser.table(:index, 0).tfoot(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.tfoot(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.table(:index, 0).tfoot(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   describe "#[]" do
     it "returns the row at the given index (page context)" do
-      browser.tfoot(:id, 'tax_totals')[0].id.should == 'tfoot_row_1'
-      browser.tfoot(:id, 'tax_totals')[0][1].text.should == '24 349'
-      browser.tfoot(:id, 'tax_totals')[0][2].text.should == '5 577'
+      expect(browser.tfoot(:id, 'tax_totals')[0].id).to eq 'tfoot_row_1'
+      expect(browser.tfoot(:id, 'tax_totals')[0][1].text).to eq '24 349'
+      expect(browser.tfoot(:id, 'tax_totals')[0][2].text).to eq '5 577'
     end
 
     it "returns the row at the given index (table context)" do
-      browser.table(:index, 0).tfoot(:id, 'tax_totals')[0].id.should == "tfoot_row_1"
-      browser.table(:index, 0).tfoot(:id, 'tax_totals')[0][1].text.should == '24 349'
-      browser.table(:index, 0).tfoot(:id, 'tax_totals')[0][2].text.should == '5 577'
+      expect(browser.table(:index, 0).tfoot(:id, 'tax_totals')[0].id).to eq "tfoot_row_1"
+      expect(browser.table(:index, 0).tfoot(:id, 'tax_totals')[0][1].text).to eq '24 349'
+      expect(browser.table(:index, 0).tfoot(:id, 'tax_totals')[0][2].text).to eq '5 577'
     end
   end
 
@@ -68,7 +68,7 @@ describe "TableFooter" do
     it "finds the first row matching the selector" do
       row = browser.tfoot(:id, 'tax_totals').row(:id => "tfoot_row_1")
 
-      row.id.should == "tfoot_row_1"
+      expect(row.id).to eq "tfoot_row_1"
     end
   end
 
@@ -76,14 +76,14 @@ describe "TableFooter" do
     it "finds rows matching the selector" do
       rows = browser.tfoot(:id, 'tax_totals').rows(:id => "tfoot_row_1")
 
-      rows.size.should == 1
-      rows.first.id.should == "tfoot_row_1"
+      expect(rows.size).to eq 1
+      expect(rows.first.id).to eq "tfoot_row_1"
     end
   end
 
   describe "#strings" do
     it "returns the text of child cells" do
-      browser.tfoot(:id, 'tax_totals').strings.should == [
+      expect(browser.tfoot(:id, 'tax_totals').strings).to eq [
         ["Sum", "24 349", "5 577", "18 722"]
       ]
     end

--- a/tfoots_spec.rb
+++ b/tfoots_spec.rb
@@ -9,35 +9,35 @@ describe "TableFooters" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.tfoots(:id => "tax_totals").to_a.should == [browser.tfoot(:id => "tax_totals")]
+        expect(browser.tfoots(:id => "tax_totals").to_a).to eq [browser.tfoot(:id => "tax_totals")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the correct number of table tfoots (page context)" do
-      browser.tfoots.length.should == 1
+      expect(browser.tfoots.length).to eq 1
     end
 
     it "returns the correct number of table tfoots (table context)" do
-      browser.table(:index, 0).tfoots.length.should == 1
+      expect(browser.table(:index, 0).tfoots.length).to eq 1
     end
   end
 
   describe "#[]" do
     it "returns the row at the given index (page context)" do
-      browser.tfoots[0].id.should == "tax_totals"
+      expect(browser.tfoots[0].id).to eq "tax_totals"
     end
 
     it "returns the row at the given index (table context)" do
-      browser.table(:index, 0).tfoots[0].id.should == "tax_totals"
+      expect(browser.table(:index, 0).tfoots[0].id).to eq "tax_totals"
     end
   end
 
   describe "#each" do
     it "iterates through table tfoots correctly (page context)" do
       browser.tfoots.each_with_index do |tfoot, index|
-        tfoot.id.should == browser.tfoot(:index, index).id
+        expect(tfoot.id).to eq browser.tfoot(:index, index).id
       end
     end
 
@@ -46,12 +46,12 @@ describe "TableFooters" do
         count = 0
 
         browser.tfoots.each_with_index do |tfoot, index|
-          tfoot.id.should == browser.tfoot(:index, index).id
+          expect(tfoot.id).to eq browser.tfoot(:index, index).id
 
           count += 1
         end
 
-        count.should > 0
+        expect(count).to be > 0
       end
 
       it "iterates through table tfoots correctly (table context)" do
@@ -59,12 +59,12 @@ describe "TableFooters" do
         count = 0
 
         table.tfoots.each_with_index do |tfoot, index|
-          tfoot.id.should == table.tfoot(:index, index).id
+          expect(tfoot.id).to eq table.tfoot(:index, index).id
 
           count += 1
         end
 
-        count.should > 0
+        expect(count).to be > 0
       end
     end
   end

--- a/thead_spec.rb
+++ b/thead_spec.rb
@@ -9,66 +9,66 @@ describe "TableHeader" do
 
   describe "#exists?" do
     it "returns true if the table theader exists (page context)" do
-      browser.thead(:id, 'tax_headers').should exist
-      browser.thead(:id, /tax_headers/).should exist
-      browser.thead(:index, 0).should exist
-      browser.thead(:xpath, "//thead[@id='tax_headers']").should exist
+      expect(browser.thead(:id, 'tax_headers')).to exist
+      expect(browser.thead(:id, /tax_headers/)).to exist
+      expect(browser.thead(:index, 0)).to exist
+      expect(browser.thead(:xpath, "//thead[@id='tax_headers']")).to exist
     end
 
     it "returns the first thead if given no args" do
-      browser.thead.should exist
+      expect(browser.thead).to exist
     end
 
     it "returns true if the table theader exists (table context)" do
-      browser.table(:index, 0).thead(:id, 'tax_headers').should exist
-      browser.table(:index, 0).thead(:id, /tax_headers/).should exist
-      browser.table(:index, 0).thead(:index, 0).should exist
-      browser.table(:index, 0).thead(:xpath, "//thead[@id='tax_headers']").should exist
+      expect(browser.table(:index, 0).thead(:id, 'tax_headers')).to exist
+      expect(browser.table(:index, 0).thead(:id, /tax_headers/)).to exist
+      expect(browser.table(:index, 0).thead(:index, 0)).to exist
+      expect(browser.table(:index, 0).thead(:xpath, "//thead[@id='tax_headers']")).to exist
     end
 
     it "returns false if the table theader doesn't exist (page context)" do
-      browser.thead(:id, 'no_such_id').should_not exist
-      browser.thead(:id, /no_such_id/).should_not exist
-      browser.thead(:index, 1337).should_not exist
-      browser.thead(:xpath, "//thead[@id='no_such_id']").should_not exist
+      expect(browser.thead(:id, 'no_such_id')).to_not exist
+      expect(browser.thead(:id, /no_such_id/)).to_not exist
+      expect(browser.thead(:index, 1337)).to_not exist
+      expect(browser.thead(:xpath, "//thead[@id='no_such_id']")).to_not exist
     end
 
     it "returns false if the table theader doesn't exist (table context)" do
-      browser.table(:index, 0).thead(:id, 'no_such_id').should_not exist
-      browser.table(:index, 0).thead(:id, /no_such_id/).should_not exist
-      browser.table(:index, 0).thead(:index, 1337).should_not exist
-      browser.table(:index, 0).thead(:xpath, "//thead[@id='no_such_id']").should_not exist
+      expect(browser.table(:index, 0).thead(:id, 'no_such_id')).to_not exist
+      expect(browser.table(:index, 0).thead(:id, /no_such_id/)).to_not exist
+      expect(browser.table(:index, 0).thead(:index, 1337)).to_not exist
+      expect(browser.table(:index, 0).thead(:xpath, "//thead[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.thead(:id, 3.14).exists? }.should raise_error(TypeError)
-      lambda { browser.table(:index, 0).thead(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.thead(:id, 3.14).exists? }.to raise_error(TypeError)
+      expect{ browser.table(:index, 0).thead(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.thead(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
-      lambda { browser.table(:index, 0).thead(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.thead(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.table(:index, 0).thead(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   describe "#[]" do
     it "returns the row at the given index (page context)" do
-      browser.thead(:id, 'tax_headers')[0].id.should == 'thead_row_1'
-      browser.thead(:id, 'tax_headers')[0][1].text.should == 'Before income tax'
-      browser.thead(:id, 'tax_headers')[0][2].text.should == 'Income tax'
+      expect(browser.thead(:id, 'tax_headers')[0].id).to eq 'thead_row_1'
+      expect(browser.thead(:id, 'tax_headers')[0][1].text).to eq 'Before income tax'
+      expect(browser.thead(:id, 'tax_headers')[0][2].text).to eq 'Income tax'
     end
 
     it "returns the row at the given index (table context)" do
-      browser.table(:index, 0).thead(:id, 'tax_headers')[0].id.should == 'thead_row_1'
-      browser.table(:index, 0).thead(:id, 'tax_headers')[0][1].text.should == 'Before income tax'
-      browser.table(:index, 0).thead(:id, 'tax_headers')[0][2].text.should == 'Income tax'
+      expect(browser.table(:index, 0).thead(:id, 'tax_headers')[0].id).to eq 'thead_row_1'
+      expect(browser.table(:index, 0).thead(:id, 'tax_headers')[0][1].text).to eq 'Before income tax'
+      expect(browser.table(:index, 0).thead(:id, 'tax_headers')[0][2].text).to eq 'Income tax'
     end
   end
 
   describe "#row" do
     it "finds the first row matching the selector" do
       row = browser.thead(:id, 'tax_headers').row(:class => "dark")
-      row.id.should == "thead_row_1"
+      expect(row.id).to eq "thead_row_1"
     end
   end
 
@@ -76,14 +76,14 @@ describe "TableHeader" do
     it "finds rows matching the selector" do
       rows = browser.thead(:id, 'tax_headers').rows(:class => "dark")
 
-      rows.size.should == 1
-      rows.first.id.should == "thead_row_1"
+      expect(rows.size).to eq 1
+      expect(rows.first.id).to eq "thead_row_1"
     end
   end
 
   describe "#strings" do
     it "returns the text of child cells" do
-      browser.thead(:id, 'tax_headers').strings.should == [
+      expect(browser.thead(:id, 'tax_headers').strings).to eq [
         ["", "Before income tax", "Income tax", "After income tax"]
       ]
     end

--- a/theads_spec.rb
+++ b/theads_spec.rb
@@ -9,35 +9,35 @@ describe "TableHeaders" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.theads(:id => "tax_headers").to_a.should == [browser.thead(:id => "tax_headers")]
+        expect(browser.theads(:id => "tax_headers").to_a).to eq [browser.thead(:id => "tax_headers")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the correct number of table theads (page context)" do
-      browser.theads.length.should == 1
+      expect(browser.theads.length).to eq 1
     end
 
     it "returns the correct number of table theads (table context)" do
-      browser.table(:index, 0).theads.length.should == 1
+      expect(browser.table(:index, 0).theads.length).to eq 1
     end
   end
 
   describe "#[]" do
     it "returns the row at the given index (page context)" do
-      browser.theads[0].id.should == "tax_headers"
+      expect(browser.theads[0].id).to eq "tax_headers"
     end
 
     it "returns the row at the given index (table context)" do
-      browser.table(:index, 0).theads[0].id.should == "tax_headers"
+      expect(browser.table(:index, 0).theads[0].id).to eq "tax_headers"
     end
   end
 
   describe "#each" do
     it "iterates through table theads correctly (page context)" do
       browser.theads.each_with_index do |thead, index|
-        thead.id.should == browser.thead(:index, index).id
+        expect(thead.id).to eq browser.thead(:index, index).id
       end
     end
 
@@ -46,12 +46,12 @@ describe "TableHeaders" do
         count = 0
 
         browser.theads.each_with_index do |thead, index|
-          thead.id.should == browser.thead(:index, index).id
+          expect(thead.id).to eq browser.thead(:index, index).id
 
           count += 1
         end
 
-        count.should > 0
+        expect(count).to be > 0
       end
 
       it "iterates through table theads correctly (table context)" do
@@ -59,12 +59,12 @@ describe "TableHeaders" do
         count = 0
 
         table.theads.each_with_index do |thead, index|
-          thead.id.should == table.thead(:index, index).id
+          expect(thead.id).to eq table.thead(:index, index).id
 
           count += 1
         end
 
-        count.should > 0
+        expect(count).to be > 0
       end
     end
   end

--- a/tr_spec.rb
+++ b/tr_spec.rb
@@ -9,29 +9,29 @@ describe "TableRow" do
 
   describe "#exists?" do
     it "returns true if the table row exists" do
-      browser.tr(:id, "outer_first").should exist
-      browser.tr(:id, /outer_first/).should exist
-      browser.tr(:index, 0).should exist
+      expect(browser.tr(:id, "outer_first")).to exist
+      expect(browser.tr(:id, /outer_first/)).to exist
+      expect(browser.tr(:index, 0)).to exist
       browser.tr(:xpath, "//tr[@id='outer_first']")
     end
 
     it "returns the first row if given no args" do
-      browser.tr.should exist
+      expect(browser.tr).to exist
     end
 
     it "returns false if the table row doesn't exist" do
-      browser.tr(:id, "no_such_id").should_not exist
-      browser.tr(:id, /no_such_id/).should_not exist
-      browser.tr(:index, 1337).should_not exist
+      expect(browser.tr(:id, "no_such_id")).to_not exist
+      expect(browser.tr(:id, /no_such_id/)).to_not exist
+      expect(browser.tr(:index, 1337)).to_not exist
       browser.tr(:xpath, "//tr[@id='no_such_id']")
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.tr(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.tr(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.tr(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.tr(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
@@ -41,7 +41,7 @@ describe "TableRow" do
       [:webdriver, :chrome] do
       it "fires the row's onclick event" do
         browser.tr(:id, 'inner_first').click
-        messages.should include('tr')
+        expect(messages).to include('tr')
       end
     end
   end
@@ -50,14 +50,14 @@ describe "TableRow" do
     let(:table) { browser.table(:id => 'outer') }
 
     it "returns the nth cell of the row" do
-      table[0][0].text.should == "Table 1, Row 1, Cell 1"
-      table[2][0].text.should == "Table 1, Row 3, Cell 1"
+      expect(table[0][0].text).to eq "Table 1, Row 1, Cell 1"
+      expect(table[2][0].text).to eq "Table 1, Row 3, Cell 1"
     end
 
     not_compliant_on :webdriver do #[] returns watir elements (lazy locate)
       it "raises UnknownCellException if the index is out of bounds" do
-        lambda { table.tr(:index, 0)[1337] }.should raise_error(UnknownCellException)
-        lambda { table[0][1337] }.should raise_error(UnknownCellException)
+        expect{ table.tr(:index, 0)[1337] }.to raise_error(UnknownCellException)
+        expect{ table[0][1337] }.to raise_error(UnknownCellException)
       end
     end
   end
@@ -66,23 +66,23 @@ describe "TableRow" do
     let(:table) { browser.table(:id => 'outer') }
 
     it "returns the correct number of cells" do
-      table[0].cells.length.should == 2
-      table[1].cells.length.should == 2
-      table[2].cells.length.should == 2
+      expect(table[0].cells.length).to eq 2
+      expect(table[1].cells.length).to eq 2
+      expect(table[2].cells.length).to eq 2
     end
 
     it "finds cells in the table" do
-      table[0].cells(:text => /Table 1/).size.should == 2
+      expect(table[0].cells(:text => /Table 1/).size).to eq 2
     end
 
     it "does not find cells from nested tables" do
-      table[1].cell(:id => "t2_r1_c1").should_not exist
-      table[1].cell(:id => /t2_r1_c1/).should_not exist
+      expect(table[1].cell(:id => "t2_r1_c1")).to_not exist
+      expect(table[1].cell(:id => /t2_r1_c1/)).to_not exist
     end
 
     it "iterates correctly through the cells of the row" do
       browser.table(:id, 'outer').row(:index => 1).cells.each_with_index do |cell, idx|
-        cell.id.should == "t1_r2_c#{idx + 1}"
+        expect(cell.id).to eq "t1_r2_c#{idx + 1}"
       end
     end
   end

--- a/trs_spec.rb
+++ b/trs_spec.rb
@@ -10,29 +10,29 @@ describe "TableRows" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.trs(:id => "outer_second").to_a.should == [browser.tr(:id => "outer_second")]
+        expect(browser.trs(:id => "outer_second").to_a).to eq [browser.tr(:id => "outer_second")]
       end
     end
   end
 
   describe "#length" do
     it "returns the correct number of cells (table context)" do
-      browser.table(:id, 'inner').trs.length.should == 1
-      browser.table(:id, 'outer').trs.length.should == 4
+      expect(browser.table(:id, 'inner').trs.length).to eq 1
+      expect(browser.table(:id, 'outer').trs.length).to eq 4
     end
 
     it "returns the correct number of cells (page context)" do
-      browser.trs.length.should == 14
+      expect(browser.trs.length).to eq 14
     end
   end
 
   describe "#[]" do
     it "returns the row at the given index (table context)" do
-      browser.table(:id, 'outer').trs[0].id.should == "outer_first"
+      expect(browser.table(:id, 'outer').trs[0].id).to eq "outer_first"
     end
 
     it "returns the row at the given index (page context)" do
-      browser.trs[0].id.should == "thead_row_1"
+      expect(browser.trs[0].id).to eq "thead_row_1"
     end
   end
 
@@ -42,10 +42,10 @@ describe "TableRows" do
       count = 0
 
       inner_table.trs.each_with_index do |r, index|
-        r.id.should == inner_table.tr(:index, index).id
+        expect(r.id).to eq inner_table.tr(:index, index).id
         count += 1
       end
-      count.should > 0
+      expect(count).to be > 0
     end
 
     it "iterates through the outer table correctly" do
@@ -53,11 +53,11 @@ describe "TableRows" do
       count = 0
 
       outer_table.trs.each_with_index do |r, index|
-        r.id.should == outer_table.tr(:index, index).id
+        expect(r.id).to eq outer_table.tr(:index, index).id
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 

--- a/ul_spec.rb
+++ b/ul_spec.rb
@@ -10,70 +10,70 @@ describe "Ul" do
   # Exists method
   describe "#exist?" do
     it "returns true if the 'ul' exists" do
-      browser.ul(:id, "navbar").should exist
-      browser.ul(:id, /navbar/).should exist
-      browser.ul(:index, 0).should exist
-      browser.ul(:xpath, "//ul[@id='navbar']").should exist
+      expect(browser.ul(:id, "navbar")).to exist
+      expect(browser.ul(:id, /navbar/)).to exist
+      expect(browser.ul(:index, 0)).to exist
+      expect(browser.ul(:xpath, "//ul[@id='navbar']")).to exist
     end
 
     it "returns the first ul if given no args" do
-      browser.ul.should exist
+      expect(browser.ul).to exist
     end
 
     it "returns false if the 'ul' doesn't exist" do
-      browser.ul(:id, "no_such_id").should_not exist
-      browser.ul(:id, /no_such_id/).should_not exist
-      browser.ul(:text, "no_such_text").should_not exist
-      browser.ul(:text, /no_such_text/).should_not exist
-      browser.ul(:class, "no_such_class").should_not exist
-      browser.ul(:class, /no_such_class/).should_not exist
-      browser.ul(:index, 1337).should_not exist
-      browser.ul(:xpath, "//ul[@id='no_such_id']").should_not exist
+      expect(browser.ul(:id, "no_such_id")).to_not exist
+      expect(browser.ul(:id, /no_such_id/)).to_not exist
+      expect(browser.ul(:text, "no_such_text")).to_not exist
+      expect(browser.ul(:text, /no_such_text/)).to_not exist
+      expect(browser.ul(:class, "no_such_class")).to_not exist
+      expect(browser.ul(:class, /no_such_class/)).to_not exist
+      expect(browser.ul(:index, 1337)).to_not exist
+      expect(browser.ul(:xpath, "//ul[@id='no_such_id']")).to_not exist
     end
 
     it "raises TypeError when 'what' argument is invalid" do
-      lambda { browser.ul(:id, 3.14).exists? }.should raise_error(TypeError)
+      expect{ browser.ul(:id, 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      lambda { browser.ul(:no_such_how, 'some_value').exists? }.should raise_error(MissingWayOfFindingObjectException)
+      expect{ browser.ul(:no_such_how, 'some_value').exists? }.to raise_error(MissingWayOfFindingObjectException)
     end
   end
 
   # Attribute methods
   describe "#class_name" do
     it "returns the class attribute" do
-      browser.ul(:id, 'navbar').class_name.should == 'navigation'
+      expect(browser.ul(:id, 'navbar').class_name).to eq 'navigation'
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.ul(:index, 1).class_name.should == ''
+      expect(browser.ul(:index, 1).class_name).to eq ''
     end
 
     it "raises UnknownObjectException if the ul doesn't exist" do
-      lambda { browser.ul(:id, 'no_such_id').class_name }.should raise_error(UnknownObjectException)
+      expect{ browser.ul(:id, 'no_such_id').class_name }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#id" do
     it "returns the id attribute" do
-      browser.ul(:class, 'navigation').id.should == "navbar"
+      expect(browser.ul(:class, 'navigation').id).to eq "navbar"
     end
 
     it "returns an empty string if the element exists and the attribute doesn't" do
-      browser.ul(:index, 1).id.should == ''
+      expect(browser.ul(:index, 1).id).to eq ''
     end
 
     it "raises UnknownObjectException if the ul doesn't exist" do
-      lambda { browser.ul(:id, "no_such_id").id }.should raise_error(UnknownObjectException)
-      lambda { browser.ul(:index, 1337).id }.should raise_error(UnknownObjectException)
+      expect{ browser.ul(:id, "no_such_id").id }.to raise_error(UnknownObjectException)
+      expect{ browser.ul(:index, 1337).id }.to raise_error(UnknownObjectException)
     end
   end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
-      browser.ul(:index, 0).should respond_to(:class_name)
-      browser.ul(:index, 0).should respond_to(:id)
+      expect(browser.ul(:index, 0)).to respond_to(:class_name)
+      expect(browser.ul(:index, 0)).to respond_to(:id)
     end
   end
 

--- a/uls_spec.rb
+++ b/uls_spec.rb
@@ -10,20 +10,20 @@ describe "Uls" do
   bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
     describe "with selectors" do
       it "returns the matching elements" do
-        browser.uls(:class => "navigation").to_a.should == [browser.ul(:class => "navigation")]
+        expect(browser.uls(:class => "navigation").to_a).to eq [browser.ul(:class => "navigation")]
       end
     end
   end
-  
+
   describe "#length" do
     it "returns the number of uls" do
-      browser.uls.length.should == 2
+      expect(browser.uls.length).to eq 2
     end
   end
 
   describe "#[]" do
     it "returns the ul at the given index" do
-      browser.uls[0].id.should == "navbar"
+      expect(browser.uls[0].id).to eq "navbar"
     end
   end
 
@@ -32,11 +32,11 @@ describe "Uls" do
       count = 0
 
       browser.uls.each_with_index do |ul, index|
-        ul.id.should == browser.ul(:index, index).id
+        expect(ul.id).to eq browser.ul(:index, index).id
         count += 1
       end
 
-      count.should > 0
+      expect(count).to be > 0
     end
   end
 end

--- a/window_switching_spec.rb
+++ b/window_switching_spec.rb
@@ -19,65 +19,65 @@ not_compliant_on [:webdriver, :iphone], [:webdriver, :safari] do
     describe "#windows" do
       it "returns an array of window handles" do
         wins = browser.windows
-        wins.should_not be_empty
-        wins.each { |win| win.should be_kind_of(Window) }
+        expect(wins).to_not be_empty
+        wins.each { |win| expect(win).to be_kind_of(Window) }
       end
 
       it "only returns windows matching the given selector" do
-        browser.windows(:title => "closeable window").size.should == 1
+        expect(browser.windows(:title => "closeable window").size).to eq 1
       end
 
       it "raises ArgumentError if the selector is invalid" do
-        lambda { browser.windows(:name => "foo") }.should raise_error(ArgumentError)
+        expect{ browser.windows(:name => "foo") }.to raise_error(ArgumentError)
       end
 
       it "raises returns an empty array if no window matches the selector" do
-        browser.windows(:title => "noop").should == []
+        expect(browser.windows(:title => "noop")).to eq []
       end
     end
 
     describe "#window" do
       it "finds window by :url" do
         w = browser.window(:url => /closeable\.html/).use
-        w.should be_kind_of(Window)
+        expect(w).to be_kind_of(Window)
       end
 
       it "finds window by :title" do
         w = browser.window(:title => "closeable window").use
-        w.should be_kind_of(Window)
+        expect(w).to be_kind_of(Window)
       end
 
       it "finds window by :index" do
         w = browser.window(:index => 1).use
-        w.should be_kind_of(Window)
+        expect(w).to be_kind_of(Window)
       end
 
       it "returns the current window if no argument is given" do
-        browser.window.url.should =~ /window_switching\.html/
+        expect(browser.window.url).to match(/window_switching\.html/)
       end
 
       bug "http://github.com/jarib/celerity/issues#issue/17", :celerity do
         it "it executes the given block in the window" do
           browser.window(:title => "closeable window") do
             link = browser.a(:id => "close")
-            link.should exist
+            expect(link).to exist
             link.click
           end.wait_while_present
 
-          browser.windows.size.should == 1
+          expect(browser.windows.size).to eq 1
         end
       end
 
       it "raises ArgumentError if the selector is invalid" do
-        lambda { browser.window(:name => "foo") }.should raise_error(ArgumentError)
+        expect{ browser.window(:name => "foo") }.to raise_error(ArgumentError)
       end
 
       it "raises an error if no window matches the selector" do
-        lambda { browser.window(:title => "noop").use }.should raise_error
+        expect{ browser.window(:title => "noop").use }.to raise_error
       end
 
       it "raises an error if there's no window at the given index" do
-        lambda { browser.window(:index => 100).use }.should raise_error
+        expect{ browser.window(:index => 100).use }.to raise_error
       end
 
     end
@@ -96,72 +96,72 @@ not_compliant_on [:webdriver, :iphone], [:webdriver, :safari] do
 
       describe "#close" do
         it "closes the window" do
-          browser.windows.size.should == 2
+          expect(browser.windows.size).to eq 2
 
           browser.a(:id => "open").click
-          browser.windows.size.should == 3
+          expect(browser.windows.size).to eq 3
 
           browser.window(:title => "closeable window").close
-          browser.windows.size.should == 2
+          expect(browser.windows.size).to eq 2
         end
       end
 
       describe "#use" do
         it "switches to the window" do
           browser.window(:title => "closeable window").use
-          browser.title.should == "closeable window"
+          expect(browser.title).to eq "closeable window"
         end
       end
 
       describe "#current?" do
         it "returns true if it is the current window" do
-          browser.window(:title => browser.title).should be_current
+          expect(browser.window(:title => browser.title)).to be_current
         end
 
         it "returns false if it is not the current window" do
-          browser.window(:title => "closeable window").should_not be_current
+          expect(browser.window(:title => "closeable window")).to_not be_current
         end
       end
 
       describe "#title" do
         it "returns the title of the window" do
           titles = browser.windows.map { |e| e.title }
-          titles.size.should == 2
+          expect(titles.size).to eq 2
 
-          titles.sort.should == ["window switching", "closeable window"].sort
+          expect(titles.sort).to eq ["window switching", "closeable window"].sort
         end
 
         it "does not change the current window" do
-          browser.title.should == "window switching"
-          browser.windows.find { |w| w.title ==  "closeable window" }.should_not be_nil
-          browser.title.should == "window switching"
+          expect(browser.title).to eq "window switching"
+          expect(browser.windows.find { |w| w.title ==  "closeable window" }).to_not be_nil
+          expect(browser.title).to eq "window switching"
         end
       end
 
       describe "#url" do
         it "returns the url of the window" do
-          browser.windows.size.should == 2
-          browser.windows.select { |w| w.url =~ /window_switching\.html/ }.size.should == 1
-          browser.windows.select { |w| w.url =~ /closeable\.html$/ }.size.should == 1
+          expect(browser.windows.size).to eq 2
+          expect(browser.windows.select { |w| w.url =~ (/window_switching\.html/) }.size).to eq 1
+          expect(browser.windows.select { |w| w.url =~ (/closeable\.html$/) }.size).to eq 1
         end
 
         it "does not change the current window" do
-          browser.url.should =~ /window_switching\.html/
-          browser.windows.find { |w| w.url =~ /closeable\.html/ }.should_not be_nil
-          browser.url.should =~ /window_switching/
+          expect(browser.url).to match(/window_switching\.html/)
+          expect(browser.windows.find { |w| w.url =~ (/closeable\.html/) }).to_not be_nil
+          expect(browser.url).to match(/window_switching/)
         end
       end
 
-      describe "#==" do
+      describe "#eq" do
         it "knows when two windows are equal" do
-          browser.window.should == browser.window
+          expect(browser.window).to eq browser.window
         end
 
         it "knows when two windows are not equal" do
           win1 = browser.window
           win2 = browser.window(:title => "closeable window")
 
-          win1.should_not == win2
+          expect(win1).to_not eq win2
         end
       end
 
@@ -173,13 +173,13 @@ not_compliant_on [:webdriver, :iphone], [:webdriver, :safari] do
             did_yield = true
           end
 
-          did_yield.should be_true
+          expect(did_yield).to be_true
         end
 
         it "times out waiting for a non-present window" do
-          lambda {
+          expect{
             browser.window(:title => "noop").wait_until_present(0.5)
-          }.should raise_error(Wait::TimeoutError)
+          }.to raise_error(Wait::TimeoutError)
         end
       end
     end
@@ -193,15 +193,15 @@ not_compliant_on [:webdriver, :iphone], [:webdriver, :safari] do
         it "should get the size of the current window" do
           size = browser.window.size
 
-          size.width.should > 0
-          size.height.should > 0
+          expect(size.width).to be > 0
+          expect(size.height).to be > 0
         end
 
         it "should get the position of the current window" do
           pos = browser.window.position
 
-          pos.x.should >= 0
-          pos.y.should >= 0
+          expect(pos.x).to be >= 0
+          expect(pos.y).to be >= 0
         end
       end
 
@@ -214,8 +214,8 @@ not_compliant_on [:webdriver, :iphone], [:webdriver, :safari] do
 
         new_size = browser.window.size
 
-        new_size.width.should == initial_size.width - 10
-        new_size.height.should == initial_size.height - 10
+        expect(new_size.width).to eq initial_size.width - 10
+        expect(new_size.height).to eq initial_size.height - 10
       end
 
       it "should move the window" do
@@ -227,8 +227,8 @@ not_compliant_on [:webdriver, :iphone], [:webdriver, :safari] do
         )
 
         new_pos = browser.window.position
-        new_pos.x.should == initial_pos.x + 10
-        new_pos.y.should == initial_pos.y + 10
+        expect(new_pos.x).to eq initial_pos.x + 10
+        expect(new_pos.y).to eq initial_pos.y + 10
       end
 
       compliant_on [:webdriver, :firefox, :window_manager] do
@@ -239,8 +239,8 @@ not_compliant_on [:webdriver, :iphone], [:webdriver, :safari] do
           browser.wait_until { browser.window.size != initial_size }
 
           new_size = browser.window.size
-          new_size.width.should > initial_size.width
-          new_size.height.should > initial_size.height
+          expect(new_size.width).to be > initial_size.width
+          expect(new_size.height).to be > initial_size.height
         end
       end
     end


### PR DESCRIPTION
Hi, I'd like to offer this suggestion for changes to the RSpec syntax to use expect.  More than just a style change, it has turned turned out that using 'expect' over 'should' is a recommended practice because of dealing with delegate/proxy objects as detailed in http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax
As detailed in the blog post "In the future, we plan to change the defaults so that only expect is available unless you explicitly enable should. We may do this as soon as RSpec 3.0, but we want to give users plenty of time to get acquianted with it."
I changed the pattern matchers from =~ to match() as required for this change and while at it I also took the opportunity to change the == format to eq as recommended in the post. 
I switched from lamba {} to expect{} as detailed in http://stackoverflow.com/questions/4191016/which-style-lambda-should-or-expect-to-is-preferred-for-testing-expectations?rq=1.
I made these changes in the main spec/ files and also in the these spec/watirspec files (approx 90+ files, 1000+ tests) which I forked separately here.
All tests pass.
