### PR TITLE
Rescue TypeError for #free_port?

### DIFF
--- a/lib/server.rb
+++ b/lib/server.rb
@@ -78,7 +78,7 @@ module WatirSpec
         s = TCPServer.new(@host, port)
         s.close
         true
-      rescue *SOCKET_ERRORS
+      rescue TypeError, *SOCKET_ERRORS
         false
       end
 


### PR DESCRIPTION
Running more than one watirspec test at a time gives me this:

```
/home/titus/workspace/watir-webdriver/spec/watirspec/lib/server.rb:78:in `initialize': no implicit conversion of nil into String (TypeError)
    from /home/titus/workspace/watir-webdriver/spec/watirspec/lib/server.rb:78:in `new'
    from /home/titus/workspace/watir-webdriver/spec/watirspec/lib/server.rb:78:in `free_port?'
    from /home/titus/workspace/watir-webdriver/spec/watirspec/lib/server.rb:55:in `find_free_port_above'
    from /home/titus/workspace/watir-webdriver/spec/watirspec/lib/server.rb:109:in `<class:Server>'
    from /home/titus/workspace/watir-webdriver/spec/watirspec/lib/server.rb:6:in `<module:WatirSpec>'
    from /home/titus/workspace/watir-webdriver/spec/watirspec/lib/server.rb:5:in `<top (required)>'
    from /home/titus/workspace/watir-webdriver/spec/watirspec/spec_helper.rb:11:in `require'
    from /home/titus/workspace/watir-webdriver/spec/watirspec/spec_helper.rb:11:in `<top (required)>'
    from /home/titus/workspace/watir-webdriver/spec/element_spec.rb:1:in `require'
    from /home/titus/workspace/watir-webdriver/spec/element_spec.rb:1:in `<top (required)>'
```
