### PR TITLE
Migrate Element#to_subtype examples from Watir-Webdriver

### DIFF
--- a/element_spec.rb
+++ b/element_spec.rb
@@ -114,12 +114,38 @@ describe "Element" do
   end
 
   describe "#to_subtype" do
-    it "returns a more precise subtype of Element (input element)" do
-      el = browser.element(:xpath => "//input[@type='radio']").to_subtype
-      expect(el).to be_kind_of(Watir::Radio)
+    it "returns a CheckBox instance" do
+      e = browser.input(:xpath => "//input[@type='checkbox']").to_subtype
+      expect(e).to be_kind_of(Watir::CheckBox)
     end
 
-    it "returns a more precise subtype of Element" do
+    it "returns a Radio instance" do
+      e = browser.input(:xpath => "//input[@type='radio']").to_subtype
+      expect(e).to be_kind_of(Watir::Radio)
+    end
+
+    it "returns a Button instance" do
+      es = [
+        browser.input(:xpath => "//input[@type='button']").to_subtype,
+        browser.input(:xpath => "//input[@type='submit']").to_subtype,
+        browser.input(:xpath => "//input[@type='reset']").to_subtype,
+        browser.input(:xpath => "//input[@type='image']").to_subtype
+      ]
+
+      es.all? { |e| expect(e).to be_kind_of(Watir::Button) }
+    end
+
+    it "returns a TextField instance" do
+      e = browser.input(:xpath => "//input[@type='text']").to_subtype
+      expect(e).to be_kind_of(Watir::TextField)
+    end
+
+    it "returns a FileField instance" do
+      e = browser.input(:xpath => "//input[@type='file']").to_subtype
+      expect(e).to be_kind_of(Watir::FileField)
+    end
+
+    it "returns a Div instance" do
       el = browser.element(:xpath => "//*[@id='messages']").to_subtype
       expect(el).to be_kind_of(Watir::Div)
     end


### PR DESCRIPTION
The Watir-Webdriver spec has additional examples for how the Element#to_subtype method should handle input elements. I would like to migrate these examples to Watirspec as they identify some issues with the Watir-Classic implementation. In particular, the handling of button, text and file types fail in Watir-Classic.

Changes made from the Watir-Webdriver spec:
- The name of the file type example was corrected from "returns a TextField instance" to "returns a FileField instance"
- Included the reset and image types in the button instance example
