### PR TITLE
a call to wait until with a timeout of zero should read to not wait to execute not to never execute

### DIFF
--- a/wait_spec.rb
+++ b/wait_spec.rb
@@ -8,6 +8,10 @@ not_compliant_on [:webdriver, :safari] do
         expect(Wait.until(0.5) { true }).to be true
       end
 
+      it "executes block if timeout is zero" do
+        expect(Wait.until(0) { true }).to be true
+      end
+
       it "times out" do
         expect {Wait.until(0.5) { false }}.to raise_error(Watir::Wait::TimeoutError)
       end
@@ -28,6 +32,10 @@ not_compliant_on [:webdriver, :safari] do
     describe "#while" do
       it "waits while the block returns true" do
         expect(Wait.while(0.5) { false }).to be_nil
+      end
+
+      it "executes block if timeout is zero" do
+        expect(Wait.while(0) { false }).to be_nil
       end
 
       it "times out" do


### PR DESCRIPTION
Current behavior is not specified either way, I believe this to be the correct implementation
@p0deje - I think you wrote this code, let me know if you agree