### PR TITLE
updates for safari tests passing on mac

### DIFF
--- a/alert_spec.rb
+++ b/alert_spec.rb
@@ -2,64 +2,49 @@ require File.expand_path("../spec_helper", __FILE__)
 
 describe 'Alert API' do
   bug "https://github.com/detro/ghostdriver/issues/20", :phantomjs do
-    before do
-      browser.goto WatirSpec.url_for("alerts.html")
-    end
-
-    after do
-      browser.alert.ok if browser.alert.exists?
-    end
-
-    context 'alert' do
-      describe '#text' do
-        it 'returns text of alert' do
-          not_compliant_on :watir_classic do
-            browser.button(id: 'alert').click
-          end
-
-          deviates_on :watir_classic do
-            browser.button(id: 'alert').click_no_wait
-          end
-
-          expect(browser.alert.text).to include('ok')
-        end
+    not_compliant_on %i(webdriver safari) do
+      before do
+        browser.goto WatirSpec.url_for("alerts.html")
       end
 
-      describe '#exists?' do
-        it 'returns false if alert is not present' do
-          expect(browser.alert).to_not exist
-        end
-
-        it 'returns true if alert is present' do
-          not_compliant_on :watir_classic do
-            browser.button(id: 'alert').click
-          end
-
-          deviates_on :watir_classic do
-            browser.button(id: 'alert').click_no_wait
-          end
-
-          browser.wait_until(10) { browser.alert.exists? }
-        end
+      after do
+        browser.alert.ok if browser.alert.exists?
       end
 
-      describe '#ok' do
-        it 'closes alert' do
-          not_compliant_on :watir_classic do
-            browser.button(id: 'alert').click
-          end
+      context 'alert' do
+        describe '#text' do
+          it 'returns text of alert' do
+            not_compliant_on :watir_classic do
+              browser.button(id: 'alert').click
+            end
 
-          deviates_on :watir_classic do
-            browser.button(id: 'alert').click_no_wait
-          end
+            deviates_on :watir_classic do
+              browser.button(id: 'alert').click_no_wait
+            end
 
-          browser.alert.ok
-          expect(browser.alert).to_not exist
+            expect(browser.alert.text).to include('ok')
+          end
         end
-      end
 
-      bug "https://code.google.com/p/chromedriver/issues/detail?id=26", [:chrome, :macosx] do
-        describe '#close' do
+        describe '#exists?' do
+          it 'returns false if alert is not present' do
+            expect(browser.alert).to_not exist
+          end
+
+          it 'returns true if alert is present' do
+            not_compliant_on :watir_classic do
+              browser.button(id: 'alert').click
+            end
+
+            deviates_on :watir_classic do
+              browser.button(id: 'alert').click_no_wait
+            end
+
+            browser.wait_until(10) { browser.alert.exists? }
+          end
+        end
+
+        describe '#ok' do
           it 'closes alert' do
             not_compliant_on :watir_classic do
               browser.button(id: 'alert').click
@@ -69,47 +54,47 @@ describe 'Alert API' do
               browser.button(id: 'alert').click_no_wait
             end
 
-            browser.alert.when_present.close
+            browser.alert.ok
             expect(browser.alert).to_not exist
           end
         end
-      end
 
-      describe 'when_present' do
-        it 'waits until alert is present and goes on' do
-          browser.button(id: 'timeout-alert').click
-          browser.alert.when_present.ok
+        bug "https://code.google.com/p/chromedriver/issues/detail?id=26", [:chrome, :macosx] do
+          describe '#close' do
+            it 'closes alert' do
+              not_compliant_on :watir_classic do
+                browser.button(id: 'alert').click
+              end
 
-          expect(browser.alert).to_not exist
+              deviates_on :watir_classic do
+                browser.button(id: 'alert').click_no_wait
+              end
+
+              browser.alert.when_present.close
+              expect(browser.alert).to_not exist
+            end
+          end
         end
 
-        it 'raises error if alert is not present after timeout' do
-          expect {
-            browser.alert.when_present(0.1).ok
-          }.to raise_error(Watir::Wait::TimeoutError)
-        end
-      end
-    end
+        describe 'when_present' do
+          it 'waits until alert is present and goes on' do
+            browser.button(id: 'timeout-alert').click
+            browser.alert.when_present.ok
 
-    context 'confirm' do
-      describe '#ok' do
-        it 'accepts confirm' do
-          not_compliant_on :watir_classic do
-            browser.button(id: 'confirm').click
+            expect(browser.alert).to_not exist
           end
 
-          deviates_on :watir_classic do
-            browser.button(id: 'confirm').click_no_wait
+          it 'raises error if alert is not present after timeout' do
+            expect {
+              browser.alert.when_present(0.1).ok
+            }.to raise_error(Watir::Wait::TimeoutError)
           end
-
-          browser.alert.ok
-          expect(browser.button(id: 'confirm').value).to eq "true"
         end
       end
 
-      bug "https://code.google.com/p/chromedriver/issues/detail?id=26", [:chrome, :macosx] do
-        describe '#close' do
-          it 'cancels confirm' do
+      context 'confirm' do
+        describe '#ok' do
+          it 'accepts confirm' do
             not_compliant_on :watir_classic do
               browser.button(id: 'confirm').click
             end
@@ -118,27 +103,44 @@ describe 'Alert API' do
               browser.button(id: 'confirm').click_no_wait
             end
 
-            browser.alert.when_present.close
-            expect(browser.button(id: 'confirm').value).to eq "false"
+            browser.alert.ok
+            expect(browser.button(id: 'confirm').value).to eq "true"
+          end
+        end
+
+        bug "https://code.google.com/p/chromedriver/issues/detail?id=26", [:chrome, :macosx] do
+          describe '#close' do
+            it 'cancels confirm' do
+              not_compliant_on :watir_classic do
+                browser.button(id: 'confirm').click
+              end
+
+              deviates_on :watir_classic do
+                browser.button(id: 'confirm').click_no_wait
+              end
+
+              browser.alert.when_present.close
+              expect(browser.button(id: 'confirm').value).to eq "false"
+            end
           end
         end
       end
-    end
 
-    context 'prompt' do
-      describe '#set' do
-        it 'enters text to prompt' do
-          not_compliant_on :watir_classic do
-            browser.button(id: 'prompt').click
+      context 'prompt' do
+        describe '#set' do
+          it 'enters text to prompt' do
+            not_compliant_on :watir_classic do
+              browser.button(id: 'prompt').click
+            end
+
+            deviates_on :watir_classic do
+              browser.button(id: 'prompt').click_no_wait
+            end
+
+            browser.alert.set 'My Name'
+            browser.alert.ok
+            expect(browser.button(id: 'prompt').value).to eq 'My Name'
           end
-
-          deviates_on :watir_classic do
-            browser.button(id: 'prompt').click_no_wait
-          end
-
-          browser.alert.set 'My Name'
-          browser.alert.ok
-          expect(browser.button(id: 'prompt').value).to eq 'My Name'
         end
       end
     end

--- a/browser_spec.rb
+++ b/browser_spec.rb
@@ -211,7 +211,7 @@ describe "Browser" do
 
     it "updates the page when location is changed with setTimeout + window.location" do
       browser.goto(WatirSpec.url_for("timeout_window_location.html"))
-      sleep 1
+      Watir::Wait.while {browser.url.include? 'timeout_window_location.html'}
       expect(browser.url).to include("non_control_elements.html")
     end
   end
@@ -264,44 +264,46 @@ describe "Browser" do
     end
   end
 
-  describe "#back and #forward" do
-    it "goes to the previous page" do
-      browser.goto WatirSpec.url_for("non_control_elements.html", needs_server: true)
-      orig_url = browser.url
-      browser.goto(WatirSpec.url_for("tables.html", needs_server: true))
-      new_url = browser.url
-      expect(orig_url).to_not eq new_url
-      browser.back
-      expect(orig_url).to eq browser.url
-    end
-
-    it "goes to the next page" do
-      urls = []
-      browser.goto WatirSpec.url_for("non_control_elements.html", needs_server: true)
-      urls << browser.url
-      browser.goto WatirSpec.url_for("tables.html", needs_server: true)
-      urls << browser.url
-
-      browser.back
-      expect(browser.url).to eq urls.first
-      browser.forward
-      expect(browser.url).to eq urls.last
-    end
-
-    it "navigates between several history items" do
-      urls = [ "non_control_elements.html",
-               "tables.html",
-               "forms_with_input_elements.html",
-               "definition_lists.html"
-      ].map do |page|
-        browser.goto WatirSpec.url_for(page, needs_server: true)
-        browser.url
+  not_compliant_on %i(webdriver safari) do
+    describe "#back and #forward" do
+      it "goes to the previous page" do
+        browser.goto WatirSpec.url_for("non_control_elements.html", needs_server: true)
+        orig_url = browser.url
+        browser.goto(WatirSpec.url_for("tables.html", needs_server: true))
+        new_url = browser.url
+        expect(orig_url).to_not eq new_url
+        browser.back
+        expect(orig_url).to eq browser.url
       end
 
-      3.times { browser.back }
-      expect(browser.url).to eq urls.first
-      2.times { browser.forward }
-      expect(browser.url).to eq urls[2]
+      it "goes to the next page" do
+        urls = []
+        browser.goto WatirSpec.url_for("non_control_elements.html", needs_server: true)
+        urls << browser.url
+        browser.goto WatirSpec.url_for("tables.html", needs_server: true)
+        urls << browser.url
+
+        browser.back
+        expect(browser.url).to eq urls.first
+        browser.forward
+        expect(browser.url).to eq urls.last
+      end
+
+      it "navigates between several history items" do
+        urls = [ "non_control_elements.html",
+                 "tables.html",
+                 "forms_with_input_elements.html",
+                 "definition_lists.html"
+        ].map do |page|
+          browser.goto WatirSpec.url_for(page, needs_server: true)
+          browser.url
+        end
+
+        3.times { browser.back }
+        expect(browser.url).to eq urls.first
+        2.times { browser.forward }
+        expect(browser.url).to eq urls[2]
+      end
     end
   end
 

--- a/button_spec.rb
+++ b/button_spec.rb
@@ -147,13 +147,14 @@ describe "Button" do
         expect(browser.button(id: 'delete_user_submit').style).to eq "BORDER-BOTTOM: red 4px solid; BORDER-LEFT: red 4px solid; BORDER-TOP: red 4px solid; BORDER-RIGHT: red 4px solid"
       end
     end
-    deviates_on :internet_explorer9 do
+
+    deviates_on :internet_explorer9, %i(webdriver safari) do
       it "returns the style attribute if the button exists" do
         expect(browser.button(id: 'delete_user_submit').style).to eq "border: 4px solid red;"
       end
     end
 
-    deviates_on %i(webdriver iphone), %i(webdriver safari), %i(webdriver phantomjs) do
+    deviates_on %i(webdriver iphone), %i(webdriver phantomjs) do
       it "returns the style attribute if the button exists" do
         style = browser.button(id: 'delete_user_submit').style
         expect(style).to include("border-top-width: 4px;")
@@ -265,6 +266,7 @@ describe "Button" do
     it "clicks the button if it exists" do
       browser.goto(WatirSpec.url_for("forms_with_input_elements.html", needs_server: true))
       browser.button(id: 'delete_user_submit').click
+      Watir::Wait.until { !browser.url.include? 'forms_with_input_elements.html'}
       expect(browser.text).to include("Semantic table")
     end
 

--- a/cookies_spec.rb
+++ b/cookies_spec.rb
@@ -48,10 +48,15 @@ describe "Browser#cookies" do
 
       browser.cookies.add 'foo', 'bar'
       verify_cookies_count 2
+
+      compliant_on %i(webdriver safari) do
+        $browser.close
+        $browser = WatirSpec.new_browser
+      end
     end
   end
 
-  not_compliant_on %i(webdriver chrome), %i(webdriver internet_explorer), :phantomjs do
+  not_compliant_on %i(webdriver chrome), %i(webdriver internet_explorer), %i(webdriver safari), :phantomjs do
     it 'adds a cookie with options' do
       browser.goto set_cookie_url
 
@@ -93,13 +98,15 @@ describe "Browser#cookies" do
       verify_cookies_count 0
     end
 
-    it 'clears all cookies' do
-      browser.goto set_cookie_url
-      browser.cookies.add 'foo', 'bar'
-      verify_cookies_count 2
+    bug "https://code.google.com/p/selenium/issues/detail?id=5487", %i(webdriver safari) do
+      it 'clears all cookies' do
+        browser.goto set_cookie_url
+        browser.cookies.add 'foo', 'bar'
+        verify_cookies_count 2
 
-      browser.cookies.clear
-      verify_cookies_count 0
+        browser.cookies.clear
+        verify_cookies_count 0
+      end
     end
   end
 

--- a/div_spec.rb
+++ b/div_spec.rb
@@ -163,7 +163,7 @@ describe "Div" do
     end
   end
 
-  not_compliant_on %i(webdriver iphone) do
+  not_compliant_on %i(webdriver iphone), %i(webdriver safari) do
     describe "#double_click" do
       it "fires the ondblclick event" do
         browser.div(id: 'html_test').double_click

--- a/drag_and_drop_spec.rb
+++ b/drag_and_drop_spec.rb
@@ -7,7 +7,7 @@ describe "Element" do
     let(:draggable) { browser.div id: "draggable" }
     let(:droppable) { browser.div id: "droppable" }
 
-    not_compliant_on %i(webdriver iphone) do
+    not_compliant_on %i(webdriver iphone), %i(webdriver safari) do
       it "can drag and drop an element onto another" do
         expect(droppable.text).to eq 'Drop here'
         draggable.drag_and_drop_on droppable

--- a/element_spec.rb
+++ b/element_spec.rb
@@ -305,25 +305,27 @@ describe "Element" do
 
     # key combinations probably not ever possible on mobile devices?
     bug "http://code.google.com/p/chromium/issues/detail?id=93879", %i(webdriver chrome), %i(webdriver iphone) do
-      it 'performs key combinations' do
-        receiver.send_keys 'foo'
-        receiver.send_keys [@c, 'a']
-        receiver.send_keys :backspace
-        expect(receiver.value).to be_empty
-        expect(events).to eq 6
-      end
+      not_compliant_on %i(webdriver safari) do
+        it 'performs key combinations' do
+          receiver.send_keys 'foo'
+          receiver.send_keys [@c, 'a']
+          receiver.send_keys :backspace
+          expect(receiver.value).to be_empty
+          expect(events).to eq 6
+        end
 
-      it 'performs arbitrary list of key combinations' do
-        receiver.send_keys 'foo'
-        receiver.send_keys [@c, 'a'], [@c, 'x']
-        expect(receiver.value).to be_empty
-        expect(events).to eq 7
-      end
+        it 'performs arbitrary list of key combinations' do
+          receiver.send_keys 'foo'
+          receiver.send_keys [@c, 'a'], [@c, 'x']
+          expect(receiver.value).to be_empty
+          expect(events).to eq 7
+        end
 
-      it 'supports combination of strings and arrays' do
-        receiver.send_keys 'foo', [@c, 'a'], :backspace
-        expect(receiver.value).to be_empty
-        expect(events).to eq 6
+        it 'supports combination of strings and arrays' do
+          receiver.send_keys 'foo', [@c, 'a'], :backspace
+          expect(receiver.value).to be_empty
+          expect(events).to eq 6
+        end
       end
     end
   end

--- a/filefield_spec.rb
+++ b/filefield_spec.rb
@@ -109,7 +109,7 @@ describe "FileField" do
   # Manipulation methods
 
   describe "#set" do
-    not_compliant_on %i(webdriver iphone) do
+    not_compliant_on %i(webdriver iphone), %i(webdriver safari) do
       bug "https://github.com/detro/ghostdriver/issues/183", :phantomjs do
         it "is able to set a file path in the field and click the upload button and fire the onchange event" do
           browser.goto WatirSpec.url_for("forms_with_input_elements.html", needs_server: true)
@@ -135,9 +135,9 @@ describe "FileField" do
   end
 
 
-  describe "#value=" do
-    not_compliant_on %i(webdriver iphone) do
-      bug "https://github.com/detro/ghostdriver/issues/183", :phantomjs do
+  bug "https://github.com/detro/ghostdriver/issues/183", :phantomjs do
+    not_compliant_on %i(webdriver iphone), %i(webdriver safari) do
+      describe "#value=" do
         it "is able to set a file path in the field and click the upload button and fire the onchange event" do
           browser.goto WatirSpec.url_for("forms_with_input_elements.html", needs_server: true)
 
@@ -147,26 +147,24 @@ describe "FileField" do
           element.value = path
           expect(element.value).to include(File.basename(path)) # only some browser will return the full path
         end
-      end
-    end
 
-    not_compliant_on :internet_explorer, %i(webdriver chrome), %i(webdriver iphone) do
-      bug "https://github.com/detro/ghostdriver/issues/183", :phantomjs do
-        # for chrome, the check also happens in the driver
-        it "does not raise an error if the file does not exist" do
-          path = File.join(Dir.tmpdir, 'unlikely-to-exist')
-          browser.file_field.value = path
+        not_compliant_on :internet_explorer, %i(webdriver chrome) do
+          # for chrome, the check also happens in the driver
+          it "does not raise an error if the file does not exist" do
+            path = File.join(Dir.tmpdir, 'unlikely-to-exist')
+            browser.file_field.value = path
 
-          expected = path
-          expected.gsub!("/", "\\") if WatirSpec.platform == :windows
+            expected = path
+            expected.gsub!("/", "\\") if WatirSpec.platform == :windows
 
-          expect(browser.file_field.value).to include(File.basename(expected)) # only some browser will return the full path
-        end
+            expect(browser.file_field.value).to include(File.basename(expected)) # only some browser will return the full path
+          end
 
-        it "does not alter its argument" do
-          value = '/foo/bar'
-          browser.file_field.value = value
-          expect(value).to eq '/foo/bar'
+          it "does not alter its argument" do
+            value = '/foo/bar'
+            browser.file_field.value = value
+            expect(value).to eq '/foo/bar'
+          end
         end
       end
     end

--- a/form_spec.rb
+++ b/form_spec.rb
@@ -60,6 +60,7 @@ describe "Form" do
     not_compliant_on :celerity do
       it "submits the form" do
         browser.form(id: "delete_user").submit
+        Watir::Wait.until { !browser.url.include? 'forms_with_input_elements.html'}
         expect(browser.text).to include("Semantic table")
       end
 

--- a/select_list_spec.rb
+++ b/select_list_spec.rb
@@ -193,14 +193,16 @@ describe "SelectList" do
       expect { browser.select_list(name: 'no_such_name').clear }.to raise_error(Watir::Exception::UnknownObjectException)
     end
 
-    it "fires onchange event" do
-      browser.select_list(name: "new_user_languages").clear
-      expect(messages.size).to eq 2
-    end
+    not_compliant_on %i(webdriver safari) do
+      it "fires onchange event" do
+        browser.select_list(name: "new_user_languages").clear
+        expect(messages.size).to eq 2
+      end
 
-    it "doesn't fire onchange event for already cleared option" do
-      browser.select_list(name: "new_user_languages").option.clear
-      expect(messages.size).to eq 0
+      it "doesn't fire onchange event for already cleared option" do
+        browser.select_list(name: "new_user_languages").option.clear
+        expect(messages.size).to eq 0
+      end
     end
   end
 
@@ -282,18 +284,20 @@ describe "SelectList" do
       expect(browser.select_list(name: "new_user_languages").select(/ish/)).to eq "Danish"
     end
 
-    it "fires onchange event when selecting an item" do
-      browser.select_list(id: "new_user_languages").select("Danish")
-      expect(messages).to eq ['changed language']
-    end
+    not_compliant_on %i(webdriver safari) do
+      it "fires onchange event when selecting an item" do
+        browser.select_list(id: "new_user_languages").select("Danish")
+        expect(messages).to eq ['changed language']
+      end
 
-    it "doesn't fire onchange event when selecting an already selected item" do
-      browser.select_list(id: "new_user_languages").clear # removes the two pre-selected options
-      browser.select_list(id: "new_user_languages").select("English")
-      expect(messages.size).to eq 3
+      it "doesn't fire onchange event when selecting an already selected item" do
+        browser.select_list(id: "new_user_languages").clear # removes the two pre-selected options
+        browser.select_list(id: "new_user_languages").select("English")
+        expect(messages.size).to eq 3
 
-      browser.select_list(id: "new_user_languages").select("English")
-      expect(messages.size).to eq 3
+        browser.select_list(id: "new_user_languages").select("English")
+        expect(messages.size).to eq 3
+      end
     end
 
     it "returns the text of the selected option" do


### PR DESCRIPTION
All the tests pass with this, but some things I'm not sure on...

1) Why aren't safari tests that have clearly never worked not already guarded against?
2) Why we are doing not_compliant %i(webdriver __browsername__) if it is any other browser than IE?
3) How should the bug/not_compliant nestings go? Before describes? After? I think I tidied some up, but I’m not sure they are consistent across the tests now.
