### PR TITLE
add test for select list #include? by label

### DIFF
--- a/select_list_spec.rb
+++ b/select_list_spec.rb
@@ -207,8 +207,12 @@ describe "SelectList" do
   end
 
   describe "#include?" do
-    it "returns true if the given option exists" do
+    it "returns true if the given option exists by text" do
       expect(browser.select_list(name: 'new_user_country')).to include('Denmark')
+    end
+
+    it "returns true if the given option exists by label" do
+      expect(browser.select_list(name: 'new_user_country')).to include('Germany')
     end
 
     it "returns false if the given option doesn't exist" do


### PR DESCRIPTION
For https://github.com/watir/watir-webdriver/pull/375

The "Germany" option is defined in the test html only by label: https://github.com/watir/watirspec/blob/master/html/forms_with_input_elements.html#L36