### PR TITLE
Deprecated implementations

### DIFF
--- a/areas_spec.rb
+++ b/areas_spec.rb
@@ -7,11 +7,9 @@ describe "Areas" do
     browser.goto(WatirSpec.url_for("images.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.areas(alt: "Tables").to_a).to eq [browser.area(alt: "Tables")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.areas(alt: "Tables").to_a).to eq [browser.area(alt: "Tables")]
     end
   end
 

--- a/browser_spec.rb
+++ b/browser_spec.rb
@@ -45,14 +45,8 @@ describe "Browser" do
         expect(html).to include(' http-equiv="content-type"')
       end
 
-      deviates_on :internet_explorer9, :internet_explorer10 do
-        expect(html).to include(' http-equiv="content-type"')
-      end
-
-      not_compliant_on :internet_explorer9, :internet_explorer10 do
-        deviates_on :internet_explorer do
-          expect(html).to include(' http-equiv=content-type')
-        end
+      deviates_on :internet_explorer do
+        expect(html).to include(' http-equiv=content-type')
       end
     end
   end
@@ -70,7 +64,7 @@ describe "Browser" do
     #
     # for IE9, this needs to be enabled in
     # View => Toolbars -> Status bar
-    not_compliant_on %i(webdriver firefox), :internet_explorer9, :internet_explorer10 do
+    not_compliant_on %i(webdriver firefox) do
       it "returns the current value of window.status" do
         browser.goto(WatirSpec.url_for("non_control_elements.html"))
 
@@ -214,7 +208,7 @@ describe "Browser" do
 
     it "updates the page when location is changed with setTimeout + window.location" do
       browser.goto(WatirSpec.url_for("timeout_window_location.html"))
-      Watir::Wait.while {browser.url.include? 'timeout_window_location.html'}
+      Watir::Wait.while { browser.url.include? 'timeout_window_location.html' }
       expect(browser.url).to include("non_control_elements.html")
     end
   end

--- a/browser_spec.rb
+++ b/browser_spec.rb
@@ -22,12 +22,10 @@ describe "Browser" do
       expect(browser.exists?).to be false
     end
 
-    not_compliant_on(:safariwatir) do
-      it "returns false after Browser#close" do
-        b = WatirSpec.new_browser
-        b.close
-        expect(b).to_not exist
-      end
+    it "returns false after Browser#close" do
+      b = WatirSpec.new_browser
+      b.close
+      expect(b).to_not exist
     end
   end
 
@@ -141,14 +139,12 @@ describe "Browser" do
   end
 
   describe ".start" do
-    not_compliant_on %i(webdriver safariwatir) do
-      it "goes to the given URL and return an instance of itself" do
-        browser = WatirSpec.implementation.browser_class.start(WatirSpec.url_for("non_control_elements.html"))
+    it "goes to the given URL and return an instance of itself" do
+      browser = WatirSpec.implementation.browser_class.start(WatirSpec.url_for("non_control_elements.html"))
 
-        expect(browser).to be_instance_of(WatirSpec.implementation.browser_class)
-        expect(browser.title).to eq "Non-control elements"
-        browser.close
-      end
+      expect(browser).to be_instance_of(WatirSpec.implementation.browser_class)
+      expect(browser.title).to eq "Non-control elements"
+      browser.close
     end
 
     # we need to specify what browser to use

--- a/button_spec.rb
+++ b/button_spec.rb
@@ -141,13 +141,7 @@ describe "Button" do
       end
     end
 
-    deviates_on :internet_explorer8 do
-      it "returns the style attribute if the button exists" do
-        expect(browser.button(id: 'delete_user_submit').style).to eq "BORDER-BOTTOM: red 4px solid; BORDER-LEFT: red 4px solid; BORDER-TOP: red 4px solid; BORDER-RIGHT: red 4px solid"
-      end
-    end
-
-    deviates_on :internet_explorer9, %i(webdriver safari) do
+    deviates_on %i(webdriver safari) do
       it "returns the style attribute if the button exists" do
         expect(browser.button(id: 'delete_user_submit').style).to eq "border: 4px solid red;"
       end

--- a/buttons_spec.rb
+++ b/buttons_spec.rb
@@ -7,11 +7,9 @@ describe "Buttons" do
     browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.buttons(name: "new_user_button").to_a).to eq [browser.button(name: "new_user_button")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.buttons(name: "new_user_button").to_a).to eq [browser.button(name: "new_user_button")]
     end
   end
 

--- a/checkboxes_spec.rb
+++ b/checkboxes_spec.rb
@@ -7,11 +7,9 @@ describe "CheckBoxes" do
     browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.checkboxes(value: "books").to_a).to eq [browser.checkbox(value: "books")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.checkboxes(value: "books").to_a).to eq [browser.checkbox(value: "books")]
     end
   end
 

--- a/dds_spec.rb
+++ b/dds_spec.rb
@@ -7,11 +7,9 @@ describe "Dds" do
     browser.goto(WatirSpec.url_for("definition_lists.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.dds(text: "11 years").to_a).to eq [browser.dd(text: "11 years")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.dds(text: "11 years").to_a).to eq [browser.dd(text: "11 years")]
     end
   end
 

--- a/dels_spec.rb
+++ b/dels_spec.rb
@@ -7,11 +7,9 @@ describe "Dels" do
     browser.goto(WatirSpec.url_for("non_control_elements.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.dels(class: "lead").to_a).to eq [browser.del(class: "lead")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.dels(class: "lead").to_a).to eq [browser.del(class: "lead")]
     end
   end
 

--- a/div_spec.rb
+++ b/div_spec.rb
@@ -95,17 +95,6 @@ describe "Div" do
       end
     end
 
-    deviates_on :internet_explorer8 do
-      it "returns the style attribute if the element exists" do
-        expect(browser.div(id: 'best_language').style).to eq "COLOR: red; CURSOR: pointer; TEXT-DECORATION: underline"
-      end
-    end
-    deviates_on :internet_explorer9 do
-      it "returns the style attribute if the element exists" do
-        expect(browser.div(id: 'best_language').style).to eq "color: red; text-decoration: underline; cursor: pointer;"
-      end
-    end
-
     it "returns an empty string if the element exists but the attribute doesn't" do
       expect(browser.div(id: 'promo').style).to eq ""
     end
@@ -200,16 +189,6 @@ describe "Div" do
         html = browser.div(id: 'footer').html.downcase
         expect(html).to include('title="closing remarks"')
         expect(html).to_not include('</body>')
-        deviates_on :internet_explorer8 do
-          expect(html).to include('id=footer')
-          expect(html).to include('class=profile')
-          expect(html).to_not include('<div id=content>')
-        end
-        deviates_on :internet_explorer9 do
-          expect(html).to include('id="footer"')
-          expect(html).to include('class="profile"')
-          expect(html).to_not include('<div id="content">')
-        end
       end
     end
   end

--- a/divs_spec.rb
+++ b/divs_spec.rb
@@ -7,11 +7,9 @@ describe "Divs" do
     browser.goto(WatirSpec.url_for("non_control_elements.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.divs(id: "header").to_a).to eq [browser.div(id: "header")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.divs(id: "header").to_a).to eq [browser.div(id: "header")]
     end
   end
 

--- a/dl_spec.rb
+++ b/dl_spec.rb
@@ -123,14 +123,8 @@ describe "Dl" do
         expect(html).to include('<dt class="current-industry">')
       end
 
-      deviates_on :internet_explorer9, :internet_explorer10 do
-        expect(html).to include('<dt class="current-industry">')
-      end
-
-      not_compliant_on :internet_explorer9, :internet_explorer10 do
-        deviates_on :internet_explorer do
-          expect(html).to include('<dt class=current-industry>')
-        end
+      deviates_on :internet_explorer do
+        expect(html).to include('<dt class=current-industry>')
       end
 
       expect(html).to_not include('</body>')

--- a/dls_spec.rb
+++ b/dls_spec.rb
@@ -7,11 +7,9 @@ describe "Dls" do
     browser.goto(WatirSpec.url_for("definition_lists.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.dls(title: "experience").to_a).to eq [browser.dl(title: "experience")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.dls(title: "experience").to_a).to eq [browser.dl(title: "experience")]
     end
   end
 

--- a/dts_spec.rb
+++ b/dts_spec.rb
@@ -7,11 +7,9 @@ describe "Dts" do
     browser.goto(WatirSpec.url_for("definition_lists.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.dts(class: "current-industry").to_a).to eq [browser.dt(class: "current-industry")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.dts(class: "current-industry").to_a).to eq [browser.dt(class: "current-industry")]
     end
   end
 

--- a/element_spec.rb
+++ b/element_spec.rb
@@ -51,28 +51,24 @@ describe "Element" do
   describe "data-* attributes" do
     before { browser.goto WatirSpec.url_for("data_attributes.html") }
 
-    bug "http://github.com/jarib/celerity/issues#issue/27", :celerity do
-      it "finds elements by a data-* attribute" do
-        expect(browser.p(data_type: "ruby-library")).to exist
-      end
+    it "finds elements by a data-* attribute" do
+      expect(browser.p(data_type: "ruby-library")).to exist
+    end
 
-      it "returns the value of a data-* attribute" do
-        expect(browser.p.data_type).to eq "ruby-library"
-      end
+    it "returns the value of a data-* attribute" do
+      expect(browser.p.data_type).to eq "ruby-library"
     end
   end
 
   describe "aria-* attributes" do
     before { browser.goto WatirSpec.url_for("aria_attributes.html") }
 
-    bug "http://github.com/jarib/celerity/issues#issue/27", :celerity do
-      it "finds elements by a aria-* attribute" do
-        expect(browser.p(aria_label: "ruby-library")).to exist
-      end
+    it "finds elements by a aria-* attribute" do
+      expect(browser.p(aria_label: "ruby-library")).to exist
+    end
 
-      it "returns the value of a aria-* attribute" do
-        expect(browser.p.aria_label).to eq "ruby-library"
-      end
+    it "returns the value of a aria-* attribute" do
+      expect(browser.p.aria_label).to eq "ruby-library"
     end
   end
 
@@ -178,14 +174,12 @@ describe "Element" do
   end
 
   describe "#parent" do
-    bug "http://github.com/jarib/celerity/issues#issue/28", :celerity do
-      it "gets the parent of this element" do
-        expect(browser.text_field(id: "new_user_email").parent).to be_instance_of(FieldSet)
-      end
+    it "gets the parent of this element" do
+      expect(browser.text_field(id: "new_user_email").parent).to be_instance_of(FieldSet)
+    end
 
-      it "returns nil if the element has no parent" do
-        expect(browser.body.parent.parent).to be_nil
-      end
+    it "returns nil if the element has no parent" do
+      expect(browser.body.parent.parent).to be_nil
     end
   end
 

--- a/ems_spec.rb
+++ b/ems_spec.rb
@@ -7,11 +7,9 @@ describe "Ems" do
     browser.goto(WatirSpec.url_for("non_control_elements.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.ems(class: "important-class").to_a).to eq [browser.em(class: "important-class")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.ems(class: "important-class").to_a).to eq [browser.em(class: "important-class")]
     end
   end
 

--- a/filefields_spec.rb
+++ b/filefields_spec.rb
@@ -7,11 +7,9 @@ describe "FileFields" do
     browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.file_fields(class: "portrait").to_a).to eq [browser.file_field(class: "portrait")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.file_fields(class: "portrait").to_a).to eq [browser.file_field(class: "portrait")]
     end
   end
 
@@ -33,7 +31,7 @@ describe "FileFields" do
 
       browser.file_fields.each_with_index do |f, index|
         expect(f.name).to eq browser.file_field(index: index).name
-        expect(f.id).to eq  browser.file_field(index: index).id
+        expect(f.id).to eq browser.file_field(index: index).id
         expect(f.value).to eq browser.file_field(index: index).value
 
         count += 1

--- a/font_spec.rb
+++ b/font_spec.rb
@@ -7,26 +7,24 @@ describe "Font" do
     browser.goto(WatirSpec.url_for("font.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/29", :celerity do
-    it "finds the font element" do
-      expect(browser.font(index: 0)).to exist
-    end
+  it "finds the font element" do
+    expect(browser.font(index: 0)).to exist
+  end
 
-    it "knows about the color attribute" do
-      expect(browser.font(index: 0).color).to eq "#ff00ff"
-    end
+  it "knows about the color attribute" do
+    expect(browser.font(index: 0).color).to eq "#ff00ff"
+  end
 
-    it "knows about the face attribute" do
-      expect(browser.font(index: 0).face).to eq "Helvetica"
-    end
+  it "knows about the face attribute" do
+    expect(browser.font(index: 0).face).to eq "Helvetica"
+  end
 
-    it "knows about the size attribute" do
-      expect(browser.font(index: 0).size).to eq "12"
-    end
+  it "knows about the size attribute" do
+    expect(browser.font(index: 0).size).to eq "12"
+  end
 
-    it "finds all font elements" do
-      expect(browser.fonts.size).to eq 1
-    end
+  it "finds all font elements" do
+    expect(browser.fonts.size).to eq 1
   end
 
 end

--- a/form_spec.rb
+++ b/form_spec.rb
@@ -57,21 +57,18 @@ describe "Form" do
   end
 
   describe "#submit" do
-    not_compliant_on :celerity do
-      it "submits the form" do
-        browser.form(id: "delete_user").submit
-        Watir::Wait.until { !browser.url.include? 'forms_with_input_elements.html'}
-        expect(browser.text).to include("Semantic table")
-      end
+    it "submits the form" do
+      browser.form(id: "delete_user").submit
+      Watir::Wait.until { !browser.url.include? 'forms_with_input_elements.html' }
+      expect(browser.text).to include("Semantic table")
+    end
 
-      it "triggers onsubmit event and takes its result into account" do
-        form = browser.form(name: "user_new")
-        form.submit
-        expect(form).to exist
-        expect(messages.size).to eq 1
-        expect(messages[0]).to eq "submit"
-      end
-
+    it "triggers onsubmit event and takes its result into account" do
+      form = browser.form(name: "user_new")
+      form.submit
+      expect(form).to exist
+      expect(messages.size).to eq 1
+      expect(messages[0]).to eq "submit"
     end
   end
 

--- a/form_spec.rb
+++ b/form_spec.rb
@@ -17,12 +17,6 @@ describe "Form" do
 
       expect(browser.form(method: 'post')).to exist
       expect(browser.form(method: /post/)).to exist
-      deviates_on :internet_explorer8 do
-        expect(browser.form(action: 'post_to_me')).to exist
-      end
-      deviates_on :internet_explorer9 do
-        expect(browser.form(action: /post_to_me/)).to exist
-      end
       expect(browser.form(action: /to_me/)).to exist
       expect(browser.form(index: 0)).to exist
       expect(browser.form(xpath: "//form[@id='new_user']")).to exist

--- a/forms_spec.rb
+++ b/forms_spec.rb
@@ -7,11 +7,9 @@ describe "Forms" do
     browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.forms(method: "post").to_a).to eq [browser.form(method: "post")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.forms(method: "post").to_a).to eq [browser.form(method: "post")]
     end
   end
 

--- a/frames_spec.rb
+++ b/frames_spec.rb
@@ -7,11 +7,9 @@ describe "Frames" do
     browser.goto(WatirSpec.url_for("frames.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.frames(name: "frame2").to_a).to eq [browser.frame(name: "frame2")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.frames(name: "frame2").to_a).to eq [browser.frame(name: "frame2")]
     end
   end
 

--- a/hiddens_spec.rb
+++ b/hiddens_spec.rb
@@ -7,11 +7,9 @@ describe "Hiddens" do
     browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.hiddens(value: "dolls").to_a).to eq [browser.hidden(value: "dolls")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.hiddens(value: "dolls").to_a).to eq [browser.hidden(value: "dolls")]
     end
   end
 

--- a/hns_spec.rb
+++ b/hns_spec.rb
@@ -6,11 +6,9 @@ describe ["H1s", "H2s", "H3s", "H4s", "H5s", "H6s"] do
     browser.goto(WatirSpec.url_for("non_control_elements.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.h1s(class: "primary").to_a).to eq [browser.h1(class: "primary")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.h1s(class: "primary").to_a).to eq [browser.h1(class: "primary")]
     end
   end
 

--- a/iframes_spec.rb
+++ b/iframes_spec.rb
@@ -7,11 +7,9 @@ describe "IFrames" do
     browser.goto(WatirSpec.url_for("iframes.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.iframes(id: "iframe_2").to_a).to eq [browser.iframe(id: "iframe_2")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.iframes(id: "iframe_2").to_a).to eq [browser.iframe(id: "iframe_2")]
     end
   end
 

--- a/images_spec.rb
+++ b/images_spec.rb
@@ -7,11 +7,9 @@ describe "Images" do
     browser.goto(WatirSpec.url_for("images.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.images(alt: "circle").to_a).to eq [browser.image(alt: "circle")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.images(alt: "circle").to_a).to eq [browser.image(alt: "circle")]
     end
   end
 

--- a/inses_spec.rb
+++ b/inses_spec.rb
@@ -7,11 +7,9 @@ describe "Inses" do
     browser.goto(WatirSpec.url_for("non_control_elements.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.inses(class: "lead").to_a).to eq [browser.ins(class: "lead")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.inses(class: "lead").to_a).to eq [browser.ins(class: "lead")]
     end
   end
 

--- a/labels_spec.rb
+++ b/labels_spec.rb
@@ -7,11 +7,9 @@ describe "Labels" do
     browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.labels(for: "new_user_first_name").to_a).to eq [browser.label(for: "new_user_first_name")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.labels(for: "new_user_first_name").to_a).to eq [browser.label(for: "new_user_first_name")]
     end
   end
 

--- a/lib/implementation.rb
+++ b/lib/implementation.rb
@@ -46,13 +46,10 @@ if __FILE__ == $0
           {name: :deviates,      data: {file: "./spec/watirspec/div_spec.rb:114"}},
           {name: :not_compliant, data: {file: "./spec/watirspec/div_spec.rb:200"}},
           {name: :bug,           data: {file: "./spec/watirspec/div_spec.rb:228", key: "WTR-350"}}
-        ],
-        [:celerity] => [
-          {name: :deviates,      data: {file: "./spec/watirspec/div_spec.rb:143"}}
         ]
       }
-      @impl.name = :celerity
-      @impl.matching_guards_in(guards).should == [{name: :deviates, data: {file: "./spec/watirspec/div_spec.rb:143"}}]
+      @impl.name = :watir_classic
+      @impl.matching_guards_in(guards).should == [{name: :deviates, data: {file: "./spec/watirspec/div_spec.rb:114"}}]
     end
   end
 end

--- a/links_spec.rb
+++ b/links_spec.rb
@@ -7,11 +7,9 @@ describe "Links" do
     browser.goto(WatirSpec.url_for("non_control_elements.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.links(title: "link_title_2").to_a).to eq [browser.link(title: "link_title_2")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.links(title: "link_title_2").to_a).to eq [browser.link(title: "link_title_2")]
     end
   end
 

--- a/lis_spec.rb
+++ b/lis_spec.rb
@@ -7,11 +7,9 @@ describe "Lis" do
     browser.goto(WatirSpec.url_for("non_control_elements.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.lis(class: "nonlink").to_a).to eq [browser.li(class: "nonlink")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.lis(class: "nonlink").to_a).to eq [browser.li(class: "nonlink")]
     end
   end
 

--- a/maps_spec.rb
+++ b/maps_spec.rb
@@ -7,11 +7,9 @@ describe "Maps" do
     browser.goto(WatirSpec.url_for("images.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.maps(name: "triangle_map").to_a).to eq [browser.map(name: "triangle_map")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.maps(name: "triangle_map").to_a).to eq [browser.map(name: "triangle_map")]
     end
   end
 

--- a/metas_spec.rb
+++ b/metas_spec.rb
@@ -7,11 +7,9 @@ describe "Metas" do
     browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.metas(name: "description").to_a).to eq [browser.meta(name: "description")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.metas(name: "description").to_a).to eq [browser.meta(name: "description")]
     end
   end
 

--- a/ols_spec.rb
+++ b/ols_spec.rb
@@ -7,11 +7,9 @@ describe "Ols" do
     browser.goto(WatirSpec.url_for("non_control_elements.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.ols(class: "chemistry").to_a).to eq [browser.ol(class: "chemistry")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.ols(class: "chemistry").to_a).to eq [browser.ol(class: "chemistry")]
     end
   end
 

--- a/pres_spec.rb
+++ b/pres_spec.rb
@@ -7,11 +7,9 @@ describe "Pres" do
     browser.goto(WatirSpec.url_for("non_control_elements.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.pres(class: "c-plus-plus").to_a).to eq [browser.pre(class: "c-plus-plus")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.pres(class: "c-plus-plus").to_a).to eq [browser.pre(class: "c-plus-plus")]
     end
   end
 

--- a/ps_spec.rb
+++ b/ps_spec.rb
@@ -7,11 +7,9 @@ describe "Ps" do
     browser.goto(WatirSpec.url_for("non_control_elements.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.ps(class: "lead").to_a).to eq [browser.p(class: "lead")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.ps(class: "lead").to_a).to eq [browser.p(class: "lead")]
     end
   end
 

--- a/radios_spec.rb
+++ b/radios_spec.rb
@@ -7,11 +7,9 @@ describe "Radios" do
     browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.radios(value: "yes").to_a).to eq [browser.radio(value: "yes")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.radios(value: "yes").to_a).to eq [browser.radio(value: "yes")]
     end
   end
 
@@ -33,7 +31,7 @@ describe "Radios" do
 
       browser.radios.each_with_index do |r, index|
         expect(r.name).to eq browser.radio(index: index).name
-        expect(r.id).to eq  browser.radio(index: index).id
+        expect(r.id).to eq browser.radio(index: index).id
         expect(r.value).to eq browser.radio(index: index).value
 
         count += 1

--- a/select_list_spec.rb
+++ b/select_list_spec.rb
@@ -163,10 +163,8 @@ describe "SelectList" do
   end
 
   describe "#selected_options" do
-    not_compliant_on :safariwatir do
-      it "should raise UnknownObjectException if the select list doesn't exist" do
-        expect { browser.select_list(name: 'no_such_name').selected_options }.to raise_error(Watir::Exception::UnknownObjectException)
-      end
+    it "should raise UnknownObjectException if the select list doesn't exist" do
+      expect { browser.select_list(name: 'no_such_name').selected_options }.to raise_error(Watir::Exception::UnknownObjectException)
     end
 
     it "gets the currently selected item(s)" do

--- a/select_lists_spec.rb
+++ b/select_lists_spec.rb
@@ -7,11 +7,9 @@ describe "SelectLists" do
     browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.select_lists(name: "delete_user_username").to_a).to eq [browser.select_list(name: "delete_user_username")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.select_lists(name: "delete_user_username").to_a).to eq [browser.select_list(name: "delete_user_username")]
     end
   end
 
@@ -36,7 +34,7 @@ describe "SelectLists" do
 
       browser.select_lists.each_with_index do |l, index|
         expect(browser.select_list(index: index).name).to eq l.name
-        expect(browser.select_list(index: index).id).to eq  l.id
+        expect(browser.select_list(index: index).id).to eq l.id
         expect(browser.select_list(index: index).value).to eq l.value
 
         count += 1

--- a/spans_spec.rb
+++ b/spans_spec.rb
@@ -7,11 +7,9 @@ describe "Spans" do
     browser.goto(WatirSpec.url_for("non_control_elements.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.spans(class: "footer").to_a).to eq [browser.span(class: "footer")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.spans(class: "footer").to_a).to eq [browser.span(class: "footer")]
     end
   end
 

--- a/strongs_spec.rb
+++ b/strongs_spec.rb
@@ -7,11 +7,9 @@ describe "Strongs" do
     browser.goto(WatirSpec.url_for("non_control_elements.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.strongs(class: "descartes").to_a).to eq [browser.strong(class: "descartes")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.strongs(class: "descartes").to_a).to eq [browser.strong(class: "descartes")]
     end
   end
 
@@ -33,7 +31,7 @@ describe "Strongs" do
 
       browser.strongs.each_with_index do |s, index|
         strong = browser.strong(index: index)
-        expect(s.id).to         eq strong.id
+        expect(s.id).to eq strong.id
         expect(s.class_name).to eq strong.class_name
 
         count += 1

--- a/tables_spec.rb
+++ b/tables_spec.rb
@@ -7,11 +7,9 @@ describe "Tables" do
     browser.goto(WatirSpec.url_for("tables.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.tables(rules: "groups").to_a).to eq [browser.table(rules: "groups")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.tables(rules: "groups").to_a).to eq [browser.table(rules: "groups")]
     end
   end
 

--- a/tbodys_spec.rb
+++ b/tbodys_spec.rb
@@ -7,11 +7,9 @@ describe "TableBodies" do
     browser.goto(WatirSpec.url_for("tables.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.tbodys(id: "first").to_a).to eq [browser.tbody(id: "first")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.tbodys(id: "first").to_a).to eq [browser.tbody(id: "first")]
     end
   end
 

--- a/tds_spec.rb
+++ b/tds_spec.rb
@@ -7,11 +7,9 @@ describe "TableCells" do
     browser.goto(WatirSpec.url_for("tables.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.tds(headers: "before_tax").to_a).to eq [browser.td(headers: "before_tax")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.tds(headers: "before_tax").to_a).to eq [browser.td(headers: "before_tax")]
     end
   end
 

--- a/text_fields_spec.rb
+++ b/text_fields_spec.rb
@@ -7,11 +7,9 @@ describe "TextFields" do
     browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.text_fields(name: "new_user_email").to_a).to eq [browser.text_field(name: "new_user_email")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.text_fields(name: "new_user_email").to_a).to eq [browser.text_field(name: "new_user_email")]
     end
   end
 

--- a/tfoots_spec.rb
+++ b/tfoots_spec.rb
@@ -6,11 +6,9 @@ describe "TableFooters" do
     browser.goto(WatirSpec.url_for("tables.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.tfoots(id: "tax_totals").to_a).to eq [browser.tfoot(id: "tax_totals")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.tfoots(id: "tax_totals").to_a).to eq [browser.tfoot(id: "tax_totals")]
     end
   end
 

--- a/theads_spec.rb
+++ b/theads_spec.rb
@@ -6,11 +6,9 @@ describe "TableHeaders" do
     browser.goto(WatirSpec.url_for("tables.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.theads(id: "tax_headers").to_a).to eq [browser.thead(id: "tax_headers")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.theads(id: "tax_headers").to_a).to eq [browser.thead(id: "tax_headers")]
     end
   end
 

--- a/trs_spec.rb
+++ b/trs_spec.rb
@@ -7,11 +7,9 @@ describe "TableRows" do
     browser.goto(WatirSpec.url_for("tables.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.trs(id: "outer_second").to_a).to eq [browser.tr(id: "outer_second")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.trs(id: "outer_second").to_a).to eq [browser.tr(id: "outer_second")]
     end
   end
 

--- a/uls_spec.rb
+++ b/uls_spec.rb
@@ -7,11 +7,9 @@ describe "Uls" do
     browser.goto(WatirSpec.url_for("non_control_elements.html"))
   end
 
-  bug "http://github.com/jarib/celerity/issues#issue/25", :celerity do
-    describe "with selectors" do
-      it "returns the matching elements" do
-        expect(browser.uls(class: "navigation").to_a).to eq [browser.ul(class: "navigation")]
-      end
+  describe "with selectors" do
+    it "returns the matching elements" do
+      expect(browser.uls(class: "navigation").to_a).to eq [browser.ul(class: "navigation")]
     end
   end
 

--- a/window_switching_spec.rb
+++ b/window_switching_spec.rb
@@ -64,16 +64,14 @@ not_compliant_on %i(webdriver iphone), %i(webdriver safari) do
         expect(original_window.url).to match(/window_switching\.html/)
       end
 
-      bug "http://github.com/jarib/celerity/issues#issue/17", :celerity do
-        it "it executes the given block in the window" do
-          browser.window(title: "closeable window") do
-            link = browser.a(id: "close")
-            expect(link).to exist
-            link.click
-          end.wait_while_present
+      it "it executes the given block in the window" do
+        browser.window(title: "closeable window") do
+          link = browser.a(id: "close")
+          expect(link).to exist
+          link.click
+        end.wait_while_present
 
-          expect(browser.windows.size).to eq 1
-        end
+        expect(browser.windows.size).to eq 1
       end
 
       it "raises ArgumentError if the selector is invalid" do


### PR DESCRIPTION
This pulls out guards for safariwatir, celerity & deprecated versions of IE.
