### PR TITLE
Allow persistent browser to be restarted

### DIFF
--- a/lib/runner.rb
+++ b/lib/runner.rb
@@ -3,11 +3,21 @@ module WatirSpec
   module Runner
 
     module BrowserHelper
-      def browser; @browser; end
+      def browser
+        @browser
+      end
     end
 
     module PersistentBrowserHelper
-      def browser; $browser; end
+      def browser
+        $browser
+      end
+
+      def restart_browser!
+        $browser.close
+        $browser = WatirSpec.new_browser
+        at_exit { $browser.close }
+      end
     end
 
     module MessagesHelper

--- a/lib/watirspec.rb
+++ b/lib/watirspec.rb
@@ -1,19 +1,5 @@
 # encoding: utf-8
 
-# see http://redmine.ruby-lang.org/issues/5218
-if defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby" && RUBY_VERSION >= "1.9"
-  module Kernel
-    alias :__at_exit :at_exit
-    def at_exit(&block)
-      __at_exit do
-        exit_status = $!.status if $!.is_a?(SystemExit)
-        block.call
-        exit exit_status if exit_status
-      end
-    end
-  end
-end
-
 module WatirSpec
   class << self
     attr_accessor :browser_args, :persistent_browser, :unguarded, :implementation, :always_use_server


### PR DESCRIPTION
1.  The `at_exit` bug was fixed, so no need to monkey patch any more
2. Restarting a persisted browser requires an additional `at_exit` because starting a new browser starts a new service and adds the `Service#stop` call to the top of the `at_exit` stack. That causes the service to be stopped before the `$browser.close` can execute, which then throws an error and leaves a browser open. 
