### PR TITLE
Watir transition

### DIFF
--- a/after_hooks_spec.rb
+++ b/after_hooks_spec.rb
@@ -59,7 +59,10 @@ describe "Browser::AfterHooks" do
 
     it "runs after_hooks after Element#click" do
       browser.goto(WatirSpec.url_for("non_control_elements.html"))
-      @page_after_hook = Proc.new { @yield = browser.title == "Non-control elements" }
+      @page_after_hook = Proc.new do
+        Watir::Wait.while { browser.title.empty? }
+        @yield = browser.title == "Non-control elements"
+      end
       browser.after_hooks.add @page_after_hook
       browser.link(index: 1).click
       expect(@yield).to be true

--- a/after_hooks_spec.rb
+++ b/after_hooks_spec.rb
@@ -75,7 +75,7 @@ describe "Browser::AfterHooks" do
       end
     end
 
-    not_compliant_on :iphone, :safari do
+    not_compliant_on :safari do
       bug "Actions Endpoint Not Yet Implemented", :firefox do
         it "runs after_hooks after Element#double_click" do
           browser.goto(WatirSpec.url_for("non_control_elements.html"))

--- a/alert_spec.rb
+++ b/alert_spec.rb
@@ -73,24 +73,24 @@ describe 'Alert API' do
           end
         end
 
-        bug "https://code.google.com/p/chromedriver/issues/detail?id=26", [:chrome, :macosx] do
-          describe '#close' do
-            it 'cancels confirm' do
-              browser.button(id: 'confirm').click
-              browser.alert.when_present.close
-              expect(browser.button(id: 'confirm').value).to eq "false"
-            end
+        describe '#close' do
+          it 'cancels confirm' do
+            browser.button(id: 'confirm').click
+            browser.alert.when_present.close
+            expect(browser.button(id: 'confirm').value).to eq "false"
           end
         end
       end
 
       context 'prompt' do
         describe '#set' do
-          it 'enters text to prompt' do
-            browser.button(id: 'prompt').click
-            browser.alert.set 'My Name'
-            browser.alert.ok
-            expect(browser.button(id: 'prompt').value).to eq 'My Name'
+          bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255906", :firefox do
+            it 'enters text to prompt' do
+              browser.button(id: 'prompt').click
+              browser.alert.set 'My Name'
+              browser.alert.ok
+              expect(browser.button(id: 'prompt').value).to eq 'My Name'
+            end
           end
         end
       end

--- a/browser_spec.rb
+++ b/browser_spec.rb
@@ -76,17 +76,9 @@ describe "Browser" do
     end
   end
 
-  describe "#name" do
-    it "returns browser name" do
-      not_compliant_on :remote, :phantomjs do
-        expect(browser.name).to eq WatirSpec.implementation.browser_args[0]
-      end
-
-      deviates_on :phantomjs do
-        expect(browser.name).to be_an_instance_of(Symbol)
-      end
-
-      deviates_on :remote do
+  bug "Capitalization bug fixed in upcoming release", %i(remote firefox) do
+    describe "#name" do
+      it "returns browser name" do
         expect(browser.name).to eq WatirSpec.implementation.browser_args[1][:desired_capabilities].browser_name.to_sym
       end
     end
@@ -114,13 +106,13 @@ describe "Browser" do
   describe "#url" do
     it "returns the current url" do
       browser.goto(WatirSpec.url_for("non_control_elements.html"))
-      expect(browser.url).to eq WatirSpec.url_for("non_control_elements.html")
+      expect(browser.url.casecmp(WatirSpec.url_for("non_control_elements.html"))).to eq 0
     end
 
     it "always returns top url" do
       browser.goto(WatirSpec.url_for("frames.html"))
       browser.frame.body.exists? # switches to frame
-      expect(browser.url).to eq WatirSpec.url_for("frames.html")
+      expect(browser.url.casecmp(WatirSpec.url_for("frames.html"))).to eq 0
     end
   end
 

--- a/browser_spec.rb
+++ b/browser_spec.rb
@@ -14,20 +14,24 @@ describe "Browser" do
       expect(browser).to exist
     end
 
-    it "returns false if window is closed" do
-      browser.goto WatirSpec.url_for("window_switching.html")
-      browser.a(id: "open").click
-      Watir::Wait.until { browser.windows.size == 2 }
-      browser.window(title: "closeable window").use
-      browser.a(id: "close").click
-      Watir::Wait.until { browser.windows.size == 1 }
-      expect(browser.exists?).to be false
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1223277", :firefox do
+      it "returns false if window is closed" do
+        browser.goto WatirSpec.url_for("window_switching.html")
+        browser.a(id: "open").click
+        Watir::Wait.until { browser.windows.size == 2 }
+        browser.window(title: "closeable window").use
+        browser.a(id: "close").click
+        Watir::Wait.until { browser.windows.size == 1 }
+        expect(browser.exists?).to be false
+      end
     end
 
-    it "returns false after Browser#close" do
-      b = WatirSpec.new_browser
-      b.close
-      expect(b).to_not exist
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1290814", :firefox do
+      it "returns false after Browser#close" do
+        b = WatirSpec.new_browser
+        b.close
+        expect(b).to_not exist
+      end
     end
   end
 
@@ -64,13 +68,11 @@ describe "Browser" do
     #
     # for IE9, this needs to be enabled in
     # View => Toolbars -> Status bar
-    not_compliant_on :firefox do
-      it "returns the current value of window.status" do
-        browser.goto(WatirSpec.url_for("non_control_elements.html"))
+    it "returns the current value of window.status" do
+      browser.goto(WatirSpec.url_for("non_control_elements.html"))
 
-        browser.execute_script "window.status = 'All done!';"
-        expect(browser.status).to eq "All done!"
-      end
+      browser.execute_script "window.status = 'All done!';"
+      expect(browser.status).to eq "All done!"
     end
   end
 
@@ -137,13 +139,15 @@ describe "Browser" do
   end
 
   describe ".start" do
-    it "goes to the given URL and return an instance of itself" do
-      driver, args = WatirSpec.implementation.browser_args
-      browser = Watir::Browser.start(WatirSpec.url_for("non_control_elements.html"), driver, args)
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1290814", :firefox do
+      it "goes to the given URL and return an instance of itself" do
+        driver, args = WatirSpec.implementation.browser_args
+        browser = Watir::Browser.start(WatirSpec.url_for("non_control_elements.html"), driver, args)
 
-      expect(browser).to be_instance_of(Watir::Browser)
-      expect(browser.title).to eq "Non-control elements"
-      browser.close
+        expect(browser).to be_instance_of(Watir::Browser)
+        expect(browser.title).to eq "Non-control elements"
+        browser.close
+      end
     end
   end
 
@@ -171,7 +175,7 @@ describe "Browser" do
       end
     end
 
-    compliant_on :firefox do
+    compliant_on :ff_legacy do
       it "goes to internal Firefox URL 'about:mozilla' without raising errors" do
         expect { browser.goto("about:mozilla") }.to_not raise_error
       end
@@ -271,10 +275,10 @@ describe "Browser" do
       end
 
       it "navigates between several history items" do
-        urls = [ "non_control_elements.html",
-                 "tables.html",
-                 "forms_with_input_elements.html",
-                 "definition_lists.html"
+        urls = ["non_control_elements.html",
+                "tables.html",
+                "forms_with_input_elements.html",
+                "definition_lists.html"
         ].map do |page|
           browser.goto WatirSpec.url_for(page)
           browser.url
@@ -289,7 +293,7 @@ describe "Browser" do
   end
 
   it "raises UnknownObjectException when trying to access DOM elements on plain/text-page" do
-    browser.goto(WatirSpec.url_for("plain_text"))
+    browser.goto(WatirSpec.url_for("plain_text", needs_server: true))
     expect { browser.div(id: 'foo').id }.to raise_error(Watir::Exception::UnknownObjectException)
   end
 

--- a/button_spec.rb
+++ b/button_spec.rb
@@ -133,7 +133,7 @@ describe "Button" do
   end
 
   describe "#style" do
-    not_compliant_on :internet_explorer, :iphone, :safari do
+    not_compliant_on :internet_explorer, :safari do
       it "returns the style attribute if the button exists" do
         expect(browser.button(id: 'delete_user_submit').style).to eq "border: 4px solid red;"
       end
@@ -142,15 +142,6 @@ describe "Button" do
     deviates_on :safari do
       it "returns the style attribute if the button exists" do
         expect(browser.button(id: 'delete_user_submit').style).to eq "border: 4px solid red;"
-      end
-    end
-
-    deviates_on :iphone do
-      it "returns the style attribute if the button exists" do
-        style = browser.button(id: 'delete_user_submit').style
-        expect(style).to include("border-top-width: 4px;")
-        expect(style).to include("border-left-style: solid;")
-        expect(style).to include("border-right-color: red;")
       end
     end
 

--- a/cookies_spec.rb
+++ b/cookies_spec.rb
@@ -57,7 +57,8 @@ bug "https://github.com/ariya/phantomjs/issues/13115", :phantomjs do
       end
     end
 
-    not_compliant_on :chrome, :internet_explorer, :safari do
+    # TODO - Split this up into multiple tests or figure out which parts are not compliant
+    not_compliant_on :chrome, :internet_explorer, :safari, :firefox do
       it 'adds a cookie with options' do
         browser.goto set_cookie_url
 

--- a/div_spec.rb
+++ b/div_spec.rb
@@ -152,7 +152,7 @@ describe "Div" do
     end
   end
 
-  not_compliant_on :iphone, :safari do
+  not_compliant_on :safari do
     bug "Actions Endpoint Not Yet Implemented", :firefox do
       describe "#double_click" do
         it "fires the ondblclick event" do

--- a/div_spec.rb
+++ b/div_spec.rb
@@ -153,19 +153,23 @@ describe "Div" do
   end
 
   not_compliant_on :iphone, :safari do
-    describe "#double_click" do
-      it "fires the ondblclick event" do
-        browser.div(id: 'html_test').double_click
-        expect(messages).to include('double clicked')
+    bug "Actions Endpoint Not Yet Implemented", :firefox do
+      describe "#double_click" do
+        it "fires the ondblclick event" do
+          browser.div(id: 'html_test').double_click
+          expect(messages).to include('double clicked')
+        end
       end
     end
 
-    describe "#right_click" do
-      it "fires the oncontextmenu event" do
-        browser.goto(WatirSpec.url_for("right_click.html"))
-        browser.div(id: "click").right_click
-        bug "https://github.com/detro/ghostdriver/issues/125", :phantomjs do
-          expect(messages.first).to eq 'right-clicked'
+    bug "Actions Endpoint Not Yet Implemented", :firefox do
+      describe "#right_click" do
+        it "fires the oncontextmenu event" do
+          browser.goto(WatirSpec.url_for("right_click.html"))
+          browser.div(id: "click").right_click
+          bug "https://github.com/detro/ghostdriver/issues/125", :phantomjs do
+            expect(messages.first).to eq 'right-clicked'
+          end
         end
       end
     end

--- a/drag_and_drop_spec.rb
+++ b/drag_and_drop_spec.rb
@@ -1,47 +1,49 @@
 require File.expand_path("../spec_helper", __FILE__)
 
 describe "Element" do
-  context "drag and drop" do
-    before { browser.goto WatirSpec.url_for("drag_and_drop.html") }
+  bug "Actions Endpoint Not Yet Implemented", :firefox do
+    context "drag and drop" do
+      before { browser.goto WatirSpec.url_for("drag_and_drop.html") }
 
-    let(:draggable) { browser.div id: "draggable" }
-    let(:droppable) { browser.div id: "droppable" }
+      let(:draggable) { browser.div id: "draggable" }
+      let(:droppable) { browser.div id: "droppable" }
 
-    not_compliant_on :iphone, :safari do
-      it "can drag and drop an element onto another" do
-        expect(droppable.text).to eq 'Drop here'
-        draggable.drag_and_drop_on droppable
-        expect(droppable.text).to eq 'Dropped!'
-      end
-
-      bug "http://code.google.com/p/selenium/issues/detail?id=3075", :firefox do
-        it "can drag and drop an element onto another when draggable is out of viewport" do
-          reposition "draggable"
-          perform_drag_and_drop_on_droppable
+      not_compliant_on :iphone, :safari do
+        it "can drag and drop an element onto another" do
+          expect(droppable.text).to eq 'Drop here'
+          draggable.drag_and_drop_on droppable
+          expect(droppable.text).to eq 'Dropped!'
         end
 
-        it "can drag and drop an element onto another when droppable is out of viewport" do
-          reposition "droppable"
-          perform_drag_and_drop_on_droppable
+        bug "http://code.google.com/p/selenium/issues/detail?id=3075", :ff_legacy do
+          it "can drag and drop an element onto another when draggable is out of viewport" do
+            reposition "draggable"
+            perform_drag_and_drop_on_droppable
+          end
+
+          it "can drag and drop an element onto another when droppable is out of viewport" do
+            reposition "droppable"
+            perform_drag_and_drop_on_droppable
+          end
+        end
+
+        it "can drag an element by the given offset" do
+          expect(droppable.text).to eq 'Drop here'
+          draggable.drag_and_drop_by 200, 50
+          expect(droppable.text).to eq 'Dropped!'
+        end
+
+        def reposition(what)
+          browser.button(id: "reposition#{what.capitalize}").click
+        end
+
+        def perform_drag_and_drop_on_droppable
+          expect(droppable.text).to eq "Drop here"
+          draggable.drag_and_drop_on droppable
+          expect(droppable.text).to eq 'Dropped!'
         end
       end
 
-      it "can drag an element by the given offset" do
-        expect(droppable.text).to eq 'Drop here'
-        draggable.drag_and_drop_by 200, 50
-        expect(droppable.text).to eq 'Dropped!'
-      end
-
-      def reposition(what)
-        browser.button(id: "reposition#{what.capitalize}").click
-      end
-
-      def perform_drag_and_drop_on_droppable
-        expect(droppable.text).to eq "Drop here"
-        draggable.drag_and_drop_on droppable
-        expect(droppable.text).to eq 'Dropped!'
-      end
     end
-
   end
 end

--- a/drag_and_drop_spec.rb
+++ b/drag_and_drop_spec.rb
@@ -8,7 +8,7 @@ describe "Element" do
       let(:draggable) { browser.div id: "draggable" }
       let(:droppable) { browser.div id: "droppable" }
 
-      not_compliant_on :iphone, :safari do
+      not_compliant_on :safari do
         it "can drag and drop an element onto another" do
           expect(droppable.text).to eq 'Drop here'
           draggable.drag_and_drop_on droppable

--- a/element_spec.rb
+++ b/element_spec.rb
@@ -158,10 +158,14 @@ describe "Element" do
     end
   end
 
-  describe "#focused?" do
-    it "knows if the element is focused" do
-      expect(browser.element(id: 'new_user_first_name')).to be_focused
-      expect(browser.element(id: 'new_user_last_name')).to_not be_focused
+  bug "https://github.com/SeleniumHQ/selenium/issues/2555", %i(remote firefox) do
+    bug "https://github.com/SeleniumHQ/selenium/issues/1795", %i(remote edge) do
+      describe "#focused?" do
+        it "knows if the element is focused" do
+          expect(browser.element(id: 'new_user_first_name')).to be_focused
+          expect(browser.element(id: 'new_user_last_name')).to_not be_focused
+        end
+      end
     end
   end
 

--- a/element_spec.rb
+++ b/element_spec.rb
@@ -19,7 +19,7 @@ describe "Element" do
 
     it "raises ArgumentError if given the wrong number of arguments" do
       container = double("container").as_null_object
-      expect { Element.new(container, 1,2,3,4) }.to raise_error(ArgumentError)
+      expect { Element.new(container, 1, 2, 3, 4) }.to raise_error(ArgumentError)
       expect { Element.new(container, "foo") }.to raise_error(ArgumentError)
     end
   end
@@ -166,10 +166,12 @@ describe "Element" do
   end
 
   describe "#fire_event" do
-    it "should fire the given event" do
-      expect(browser.div(id: "onfocus_test").text).to be_empty
-      browser.text_field(id: "new_user_occupation").fire_event('onfocus')
-      expect(browser.div(id: "onfocus_test").text).to eq "changed by onfocus event"
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1290966", :firefox do
+      it "should fire the given event" do
+        expect(browser.div(id: "onfocus_test").text).to be_empty
+        browser.text_field(id: "new_user_occupation").fire_event('onfocus')
+        expect(browser.div(id: "onfocus_test").text).to eq "changed by onfocus event"
+      end
     end
   end
 
@@ -275,50 +277,52 @@ describe "Element" do
     end
   end
 
-  describe '#send_keys' do
-    before(:each) do
-      phantom = browser.driver.capabilities.browser_name == 'phantomjs'
-      @c = RUBY_PLATFORM =~ /darwin/ && !phantom ? :command : :control
-      browser.goto(WatirSpec.url_for('keylogger.html'))
-    end
+  bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255906", :firefox do
+    describe '#send_keys' do
+      before(:each) do
+        phantom = browser.driver.capabilities.browser_name == 'phantomjs'
+        @c = RUBY_PLATFORM =~ /darwin/ && !phantom ? :command : :control
+        browser.goto(WatirSpec.url_for('keylogger.html'))
+      end
 
-    let(:receiver) { browser.text_field(id: 'receiver') }
-    let(:events)   { browser.element(id: 'output').ps.size }
+      let(:receiver) { browser.text_field(id: 'receiver') }
+      let(:events)   { browser.element(id: 'output').ps.size }
 
-    it 'sends keystrokes to the element' do
-      receiver.send_keys 'hello world'
-      expect(receiver.value).to eq 'hello world'
-      expect(events).to eq 11
-    end
+      it 'sends keystrokes to the element' do
+        receiver.send_keys 'hello world'
+        expect(receiver.value).to eq 'hello world'
+        expect(events).to eq 11
+      end
 
-    it 'accepts arbitrary list of arguments' do
-      receiver.send_keys 'hello', 'world'
-      expect(receiver.value).to eq 'helloworld'
-      expect(events).to eq 10
-    end
+      it 'accepts arbitrary list of arguments' do
+        receiver.send_keys 'hello', 'world'
+        expect(receiver.value).to eq 'helloworld'
+        expect(events).to eq 10
+      end
 
-    # key combinations probably not ever possible on mobile devices?
-    bug "http://code.google.com/p/chromium/issues/detail?id=93879", :chrome, :iphone do
-      not_compliant_on :safari do
-        it 'performs key combinations' do
-          receiver.send_keys 'foo'
-          receiver.send_keys [@c, 'a']
-          receiver.send_keys :backspace
-          expect(receiver.value).to be_empty
-          expect(events).to eq 6
-        end
+      # key combinations probably not ever possible on mobile devices?
+      bug "http://code.google.com/p/chromium/issues/detail?id=93879", :chrome, :iphone do
+        not_compliant_on :safari do
+          it 'performs key combinations' do
+            receiver.send_keys 'foo'
+            receiver.send_keys [@c, 'a']
+            receiver.send_keys :backspace
+            expect(receiver.value).to be_empty
+            expect(events).to eq 6
+          end
 
-        it 'performs arbitrary list of key combinations' do
-          receiver.send_keys 'foo'
-          receiver.send_keys [@c, 'a'], [@c, 'x']
-          expect(receiver.value).to be_empty
-          expect(events).to eq 7
-        end
+          it 'performs arbitrary list of key combinations' do
+            receiver.send_keys 'foo'
+            receiver.send_keys [@c, 'a'], [@c, 'x']
+            expect(receiver.value).to be_empty
+            expect(events).to eq 7
+          end
 
-        it 'supports combination of strings and arrays' do
-          receiver.send_keys 'foo', [@c, 'a'], :backspace
-          expect(receiver.value).to be_empty
-          expect(events).to eq 6
+          it 'supports combination of strings and arrays' do
+            receiver.send_keys 'foo', [@c, 'a'], :backspace
+            expect(receiver.value).to be_empty
+            expect(events).to eq 6
+          end
         end
       end
     end

--- a/element_spec.rb
+++ b/element_spec.rb
@@ -300,8 +300,7 @@ describe "Element" do
         expect(events).to eq 10
       end
 
-      # key combinations probably not ever possible on mobile devices?
-      bug "http://code.google.com/p/chromium/issues/detail?id=93879", :chrome, :iphone do
+      bug "http://code.google.com/p/chromium/issues/detail?id=93879", :chrome do
         not_compliant_on :safari do
           it 'performs key combinations' do
             receiver.send_keys 'foo'

--- a/filefield_spec.rb
+++ b/filefield_spec.rb
@@ -109,7 +109,7 @@ describe "FileField" do
   # Manipulation methods
 
   describe "#set" do
-    not_compliant_on :iphone, :safari do
+    not_compliant_on :safari do
       bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
         bug "https://github.com/detro/ghostdriver/issues/183", :phantomjs do
           it "is able to set a file path in the field and click the upload button and fire the onchange event" do
@@ -138,7 +138,7 @@ describe "FileField" do
 
 
   bug "https://github.com/detro/ghostdriver/issues/183", :phantomjs do
-    not_compliant_on :iphone, :safari do
+    not_compliant_on :safari do
       bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
         describe "#value=" do
           it "is able to set a file path in the field and click the upload button and fire the onchange event" do

--- a/filefield_spec.rb
+++ b/filefield_spec.rb
@@ -162,10 +162,12 @@ describe "FileField" do
               expect(browser.file_field.value).to include(File.basename(expected)) # only some browser will return the full path
             end
 
-            it "does not alter its argument" do
-              value = '/foo/bar'
-              browser.file_field.value = value
-              expect(value).to eq '/foo/bar'
+            not_compliant_on %i(chrome windows) do
+              it "does not alter its argument" do
+                value = '/foo/bar'
+                browser.file_field.value = value
+                expect(value).to eq '/foo/bar'
+              end
             end
           end
         end

--- a/filefield_spec.rb
+++ b/filefield_spec.rb
@@ -110,19 +110,21 @@ describe "FileField" do
 
   describe "#set" do
     not_compliant_on :iphone, :safari do
-      bug "https://github.com/detro/ghostdriver/issues/183", :phantomjs do
-        it "is able to set a file path in the field and click the upload button and fire the onchange event" do
-          browser.goto WatirSpec.url_for("forms_with_input_elements.html")
+      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
+        bug "https://github.com/detro/ghostdriver/issues/183", :phantomjs do
+          it "is able to set a file path in the field and click the upload button and fire the onchange event" do
+            browser.goto WatirSpec.url_for("forms_with_input_elements.html")
 
-          path    = File.expand_path(__FILE__)
-          element = browser.file_field(name: "new_user_portrait")
+            path    = File.expand_path(__FILE__)
+            element = browser.file_field(name: "new_user_portrait")
 
-          element.set path
+            element.set path
 
-          expect(element.value).to include(File.basename(path)) # only some browser will return the full path
-          expect(messages.first).to include(File.basename(path))
+            expect(element.value).to include(File.basename(path)) # only some browser will return the full path
+            expect(messages.first).to include(File.basename(path))
 
-          browser.button(name: "new_user_submit").click
+            browser.button(name: "new_user_submit").click
+          end
         end
 
         it "raises an error if the file does not exist" do
@@ -137,33 +139,34 @@ describe "FileField" do
 
   bug "https://github.com/detro/ghostdriver/issues/183", :phantomjs do
     not_compliant_on :iphone, :safari do
-      describe "#value=" do
-        it "is able to set a file path in the field and click the upload button and fire the onchange event" do
-          browser.goto WatirSpec.url_for("forms_with_input_elements.html")
+      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
+        describe "#value=" do
+          it "is able to set a file path in the field and click the upload button and fire the onchange event" do
+            browser.goto WatirSpec.url_for("forms_with_input_elements.html")
 
-          path    = File.expand_path(__FILE__)
-          element = browser.file_field(name: "new_user_portrait")
+            path    = File.expand_path(__FILE__)
+            element = browser.file_field(name: "new_user_portrait")
 
-          element.value = path
-          expect(element.value).to include(File.basename(path)) # only some browser will return the full path
-        end
-
-        not_compliant_on :internet_explorer, :chrome do
-          # for chrome, the check also happens in the driver
-          it "does not raise an error if the file does not exist" do
-            path = File.join(Dir.tmpdir, 'unlikely-to-exist')
-            browser.file_field.value = path
-
-            expected = path
-            expected.gsub!("/", "\\") if WatirSpec.platform == :windows
-
-            expect(browser.file_field.value).to include(File.basename(expected)) # only some browser will return the full path
+            element.value = path
+            expect(element.value).to include(File.basename(path)) # only some browser will return the full path
           end
 
-          it "does not alter its argument" do
-            value = '/foo/bar'
-            browser.file_field.value = value
-            expect(value).to eq '/foo/bar'
+          not_compliant_on :internet_explorer do
+            it "does not raise an error if the file does not exist" do
+              path = File.join(Dir.tmpdir, 'unlikely-to-exist')
+              browser.file_field.value = path
+
+              expected = path
+              expected.gsub!("/", "\\") if WatirSpec.platform == :windows
+
+              expect(browser.file_field.value).to include(File.basename(expected)) # only some browser will return the full path
+            end
+
+            it "does not alter its argument" do
+              value = '/foo/bar'
+              browser.file_field.value = value
+              expect(value).to eq '/foo/bar'
+            end
           end
         end
       end

--- a/form_spec.rb
+++ b/form_spec.rb
@@ -50,19 +50,21 @@ describe "Form" do
     end
   end
 
-  describe "#submit" do
-    it "submits the form" do
-      browser.form(id: "delete_user").submit
-      Watir::Wait.until { !browser.url.include? 'forms_with_input_elements.html' }
-      expect(browser.text).to include("Semantic table")
-    end
+  bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1290985", :firefox do
+    describe "#submit" do
+      it "submits the form" do
+        browser.form(id: "delete_user").submit
+        Watir::Wait.until { !browser.url.include? 'forms_with_input_elements.html' }
+        expect(browser.text).to include("Semantic table")
+      end
 
-    it "triggers onsubmit event and takes its result into account" do
-      form = browser.form(name: "user_new")
-      form.submit
-      expect(form).to exist
-      expect(messages.size).to eq 1
-      expect(messages[0]).to eq "submit"
+      it "triggers onsubmit event and takes its result into account" do
+        form = browser.form(name: "user_new")
+        form.submit
+        expect(form).to exist
+        expect(messages.size).to eq 1
+        expect(messages[0]).to eq "submit"
+      end
     end
   end
 

--- a/frame_spec.rb
+++ b/frame_spec.rb
@@ -11,13 +11,15 @@ describe "Frame" do
     browser.goto(WatirSpec.url_for("frames.html"))
   end
 
-  it "handles crossframe javascript" do
-    browser.goto WatirSpec.url_for("frames.html", needs_server: true)
+  bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
+    it "handles crossframe javascript" do
+      browser.goto WatirSpec.url_for("frames.html", needs_server: true)
 
-    expect(browser.frame(id: "frame_1").text_field(name: 'senderElement').value).to eq 'send_this_value'
-    expect(browser.frame(id: "frame_2").text_field(name: 'recieverElement').value).to eq 'old_value'
-    browser.frame(id: "frame_1").button(id: 'send').click
-    expect(browser.frame(id: "frame_2").text_field(name: 'recieverElement').value).to eq 'send_this_value'
+      expect(browser.frame(id: "frame_1").text_field(name: 'senderElement').value).to eq 'send_this_value'
+      expect(browser.frame(id: "frame_2").text_field(name: 'recieverElement').value).to eq 'old_value'
+      browser.frame(id: "frame_1").button(id: 'send').click
+      expect(browser.frame(id: "frame_2").text_field(name: 'recieverElement').value).to eq 'send_this_value'
+    end
   end
 
   describe "#exist?" do
@@ -52,12 +54,14 @@ describe "Frame" do
     end
 
     bug "https://github.com/detro/ghostdriver/issues/159", :phantomjs do
-      it "handles nested frames" do
-        browser.goto(WatirSpec.url_for("nested_frames.html"))
+      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255946", :firefox do
+        it "handles nested frames" do
+          browser.goto(WatirSpec.url_for("nested_frames.html"))
 
-        browser.frame(id: "two").frame(id: "three").link(id: "four").click
+          browser.frame(id: "two").frame(id: "three").link(id: "four").click
 
-        Wait.until{ browser.title == "definition_lists" }
+          Wait.until{ browser.title == "definition_lists" }
+        end
       end
     end
 
@@ -90,9 +94,11 @@ describe "Frame" do
     expect { browser.frame(index: 0).foo }.to raise_error(NoMethodError)
   end
 
-  it "is able to set a field" do
-    browser.frame(index: 0).text_field(name: 'senderElement').set("new value")
-    expect(browser.frame(index: 0).text_field(name: 'senderElement').value).to eq "new value"
+  bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
+    it "is able to set a field" do
+      browser.frame(index: 0).text_field(name: 'senderElement').set("new value")
+      expect(browser.frame(index: 0).text_field(name: 'senderElement').value).to eq "new value"
+    end
   end
 
   it "can access the frame's parent element after use" do

--- a/frame_spec.rb
+++ b/frame_spec.rb
@@ -117,11 +117,9 @@ describe "Frame" do
   end
 
   describe "#html" do
-    not_compliant_on :iphone do
-      it "returns the full HTML source of the frame" do
-        browser.goto WatirSpec.url_for("frames.html")
-        expect(browser.frame.html.downcase).to include("<title>frame 1</title>")
-      end
+    it "returns the full HTML source of the frame" do
+      browser.goto WatirSpec.url_for("frames.html")
+      expect(browser.frame.html.downcase).to include("<title>frame 1</title>")
     end
   end
 

--- a/html/aria_attributes.html
+++ b/html/aria_attributes.html
@@ -4,6 +4,6 @@
     <title>aria-* attributes</title>
   </head>
   <body>
-    <p aria-label=ruby-library>watir-webdriver</p>
+    <p aria-label=ruby-library>watir</p>
   </body>
 </html>

--- a/html/data_attributes.html
+++ b/html/data_attributes.html
@@ -4,6 +4,6 @@
     <title>data-* attributes</title>
   </head>
   <body>
-    <p data-type=ruby-library>watir-webdriver</p>
+    <p data-type=ruby-library>watir</p>
   </body>
 </html>

--- a/iframe_spec.rb
+++ b/iframe_spec.rb
@@ -159,11 +159,9 @@ describe "IFrame" do
   end
 
   describe "#html" do
-    not_compliant_on :iphone do
-      it "returns the full HTML source of the iframe" do
-        browser.goto WatirSpec.url_for("iframes.html")
-        expect(browser.iframe.html.downcase).to include("<title>iframe 1</title>")
-      end
+    it "returns the full HTML source of the iframe" do
+      browser.goto WatirSpec.url_for("iframes.html")
+      expect(browser.iframe.html.downcase).to include("<title>iframe 1</title>")
     end
   end
 

--- a/iframe_spec.rb
+++ b/iframe_spec.rb
@@ -11,13 +11,15 @@ describe "IFrame" do
     browser.goto(WatirSpec.url_for("iframes.html"))
   end
 
-  it "handles crossframe javascript" do
-    browser.goto WatirSpec.url_for("iframes.html", needs_server: true)
+  bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255906", :firefox do
+    it "handles crossframe javascript" do
+      browser.goto WatirSpec.url_for("iframes.html", needs_server: true)
 
-    expect(browser.iframe(id: "iframe_1").text_field(name: 'senderElement').value).to eq 'send_this_value'
-    expect(browser.iframe(id: "iframe_2").text_field(name: 'recieverElement').value).to eq 'old_value'
-    browser.iframe(id: "iframe_1").button(id: 'send').click
-    expect(browser.iframe(id: "iframe_2").text_field(name: 'recieverElement').value).to eq 'send_this_value'
+      expect(browser.iframe(id: "iframe_1").text_field(name: 'senderElement').value).to eq 'send_this_value'
+      expect(browser.iframe(id: "iframe_2").text_field(name: 'recieverElement').value).to eq 'old_value'
+      browser.iframe(id: "iframe_1").button(id: 'send').click
+      expect(browser.iframe(id: "iframe_2").text_field(name: 'recieverElement').value).to eq 'send_this_value'
+    end
   end
 
   describe "#exist?" do
@@ -82,12 +84,14 @@ describe "IFrame" do
 
 
     bug "https://github.com/detro/ghostdriver/issues/159", :phantomjs do
-      it "handles nested iframes" do
-        browser.goto(WatirSpec.url_for("nested_iframes.html"))
+      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255946", :firefox do
+        it "handles nested iframes" do
+          browser.goto(WatirSpec.url_for("nested_iframes.html"))
 
-        browser.iframe(id: "two").iframe(id: "three").link(id: "four").click
+          browser.iframe(id: "two").iframe(id: "three").link(id: "four").click
 
-        Wait.until { browser.title == "definition_lists" }
+          Wait.until { browser.title == "definition_lists" }
+        end
       end
     end
 
@@ -138,9 +142,11 @@ describe "IFrame" do
     expect { browser.iframe(index: 0).foo }.to raise_error(NoMethodError)
   end
 
-  it "is able to set a field" do
-    browser.iframe(index: 0).text_field(name: 'senderElement').set("new value")
-    expect(browser.iframe(index: 0).text_field(name: 'senderElement').value).to eq "new value"
+  bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255906", :firefox do
+    it "is able to set a field" do
+      browser.iframe(index: 0).text_field(name: 'senderElement').set("new value")
+      expect(browser.iframe(index: 0).text_field(name: 'senderElement').value).to eq "new value"
+    end
   end
 
   describe "#execute_script" do

--- a/image_spec.rb
+++ b/image_spec.rb
@@ -145,22 +145,24 @@ describe "Image" do
   end
 
   # Other
-  describe "#loaded?" do
-    it "returns true if the image has been loaded" do
-      expect(browser.image(title: 'Circle')).to be_loaded
-      expect(browser.image(alt: 'circle')).to be_loaded
-      expect(browser.image(alt: /circle/)).to be_loaded
-    end
+  bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
+    describe "#loaded?" do
+      it "returns true if the image has been loaded" do
+        expect(browser.image(title: 'Circle')).to be_loaded
+        expect(browser.image(alt: 'circle')).to be_loaded
+        expect(browser.image(alt: /circle/)).to be_loaded
+      end
 
-    it "returns false if the image has not been loaded" do
-      expect(browser.image(id: 'no_such_file')).to_not be_loaded
-    end
+      it "returns false if the image has not been loaded" do
+        expect(browser.image(id: 'no_such_file')).to_not be_loaded
+      end
 
-    it "raises UnknownObjectException if the image doesn't exist" do
-      expect { browser.image(id: 'no_such_image').loaded? }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.image(src: 'no_such_image').loaded? }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.image(alt: 'no_such_image').loaded? }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.image(index: 1337).loaded? }.to raise_error(Watir::Exception::UnknownObjectException)
+      it "raises UnknownObjectException if the image doesn't exist" do
+        expect { browser.image(id: 'no_such_image').loaded? }.to raise_error(Watir::Exception::UnknownObjectException)
+        expect { browser.image(src: 'no_such_image').loaded? }.to raise_error(Watir::Exception::UnknownObjectException)
+        expect { browser.image(alt: 'no_such_image').loaded? }.to raise_error(Watir::Exception::UnknownObjectException)
+        expect { browser.image(index: 1337).loaded? }.to raise_error(Watir::Exception::UnknownObjectException)
+      end
     end
   end
 

--- a/label_spec.rb
+++ b/label_spec.rb
@@ -61,8 +61,10 @@ describe "Label" do
   end
 
   describe "#for" do
-    it "returns the 'for' attribute if the label exists" do
-      expect(browser.label(index: 0).for).to eq "new_user_first_name"
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
+      it "returns the 'for' attribute if the label exists" do
+        expect(browser.label(index: 0).for).to eq "new_user_first_name"
+      end
     end
 
     it "raises UnknownObjectException if the label doesn't exist" do
@@ -76,6 +78,5 @@ describe "Label" do
       expect(browser.label(index: 0)).to respond_to(:for)
     end
   end
-
 
 end

--- a/lib/server.rb
+++ b/lib/server.rb
@@ -97,7 +97,7 @@ module WatirSpec
     set :static,        true
     set :run,           false
     set :environment,   :production
-    set :bind,          "localhost" if WatirSpec.platform == :windows
+    set :bind,          "127.0.0.1" if WatirSpec.platform == :windows
     set :port,          pick_port_above(8180)
     set :server,        "webrick"
 

--- a/link_spec.rb
+++ b/link_spec.rb
@@ -166,6 +166,7 @@ describe "Link" do
     it "clicks a link with no text content but an img child" do
       browser.goto WatirSpec.url_for("images.html")
       browser.link(href: /definition_lists.html/).click
+      Watir::Wait.while { browser.title == "Images" || browser.title == ""}
       expect(browser.title).to eq 'definition_lists'
     end
 

--- a/option_spec.rb
+++ b/option_spec.rb
@@ -72,39 +72,41 @@ describe "Option" do
     end
   end
 
-  describe "#select" do
-    it "selects the chosen option (page context)" do
-      browser.option(text: "Denmark").select
-      expect(browser.select_list(name: "new_user_country").selected_options.map(&:text)).to eq ["Denmark"]
-    end
+  bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
+    describe "#select" do
+      it "selects the chosen option (page context)" do
+        browser.option(text: "Denmark").select
+        expect(browser.select_list(name: "new_user_country").selected_options.map(&:text)).to eq ["Denmark"]
+      end
 
-    it "selects the chosen option (select_list context)" do
-      browser.select_list(name: "new_user_country").option(text: "Denmark").select
-      expect(browser.select_list(name: "new_user_country").selected_options.map(&:text)).to eq ["Denmark"]
-    end
+      it "selects the chosen option (select_list context)" do
+        browser.select_list(name: "new_user_country").option(text: "Denmark").select
+        expect(browser.select_list(name: "new_user_country").selected_options.map(&:text)).to eq ["Denmark"]
+      end
 
-    it "selects the option when found by text (page context)" do
-      browser.option(text: 'Sweden').select
-      expect(browser.option(text: 'Sweden')).to be_selected
-    end
+      it "selects the option when found by text (page context)" do
+        browser.option(text: 'Sweden').select
+        expect(browser.option(text: 'Sweden')).to be_selected
+      end
 
-    it "selects the option when found by text (select_list context)" do
-      browser.select_list(name: 'new_user_country').option(text: 'Sweden').select
-      expect(browser.select_list(name: 'new_user_country').option(text: 'Sweden')).to be_selected
-    end
+      it "selects the option when found by text (select_list context)" do
+        browser.select_list(name: 'new_user_country').option(text: 'Sweden').select
+        expect(browser.select_list(name: 'new_user_country').option(text: 'Sweden')).to be_selected
+      end
 
-    # there's no onclick event for Option in IE / WebKit
-    # http://msdn.microsoft.com/en-us/library/ms535877(VS.85).aspx
-    compliant_on :firefox do
-      it "fires the onclick event (page context)" do
-        browser.option(text: "Username 3").select
-        expect(browser.textarea(id: 'delete_user_comment').value).to eq 'Don\'t do it!'
+      # there's no onclick event for Option in IE / WebKit
+      # http://msdn.microsoft.com/en-us/library/ms535877(VS.85).aspx
+      compliant_on :ff_legacy do
+        it "fires the onclick event (page context)" do
+          browser.option(text: "Username 3").select
+          expect(browser.textarea(id: 'delete_user_comment').value).to eq 'Don\'t do it!'
+        end
       end
     end
 
     # there's no onclick event for Option in IE / WebKit
     # http://msdn.microsoft.com/en-us/library/ms535877(VS.85).aspx
-    compliant_on :firefox do
+    compliant_on :ff_legacy do
       it "fires onclick event (select_list context)" do
         browser.select_list(id: 'delete_user_username').option(text: "Username 3").select
         expect(browser.textarea(id: 'delete_user_comment').value).to eq 'Don\'t do it!'

--- a/select_list_spec.rb
+++ b/select_list_spec.rb
@@ -91,10 +91,12 @@ describe "SelectList" do
   end
 
   describe "#value" do
-    it "returns the value of the selected option" do
-      expect(browser.select_list(index: 0).value).to eq "2"
-      browser.select_list(index: 0).select(/Sweden/)
-      expect(browser.select_list(index: 0).value).to eq "3"
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
+      it "returns the value of the selected option" do
+        expect(browser.select_list(index: 0).value).to eq "2"
+        browser.select_list(index: 0).select(/Sweden/)
+        expect(browser.select_list(index: 0).value).to eq "3"
+      end
     end
 
     it "raises UnknownObjectException if the select list doesn't exist" do
@@ -168,9 +170,11 @@ describe "SelectList" do
   end
 
   describe "#clear" do
-    it "clears the selection when possible" do
-      browser.select_list(name: "new_user_languages").clear
-      expect(browser.select_list(name: "new_user_languages").selected_options).to be_empty
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
+      it "clears the selection when possible" do
+        browser.select_list(name: "new_user_languages").clear
+        expect(browser.select_list(name: "new_user_languages").selected_options).to be_empty
+      end
     end
 
     it "does not clear selections if the select list does not allow multiple selections" do
@@ -187,9 +191,11 @@ describe "SelectList" do
 
     not_compliant_on :safari do
       bug "Not firing events", :phantomjs do
-        it "fires onchange event" do
-          browser.select_list(name: "new_user_languages").clear
-          expect(messages.size).to eq 2
+        bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
+          it "fires onchange event" do
+            browser.select_list(name: "new_user_languages").clear
+            expect(messages.size).to eq 2
+          end
         end
       end
 
@@ -215,18 +221,22 @@ describe "SelectList" do
   end
 
   describe "#selected?" do
-    it "returns true if the given option is selected by text" do
-      browser.select_list(name: 'new_user_country').select('Denmark')
-      expect(browser.select_list(name: 'new_user_country')).to be_selected('Denmark')
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
+      it "returns true if the given option is selected by text" do
+        browser.select_list(name: 'new_user_country').select('Denmark')
+        expect(browser.select_list(name: 'new_user_country')).to be_selected('Denmark')
+      end
     end
 
     it "returns false if the given option is not selected by text" do
       expect(browser.select_list(name: 'new_user_country')).to_not be_selected('Sweden')
     end
 
-    it "returns true if the given option is selected by label" do
-      browser.select_list(name: 'new_user_country').select('Germany')
-      expect(browser.select_list(name: 'new_user_country')).to be_selected('Germany')
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
+      it "returns true if the given option is selected by label" do
+        browser.select_list(name: 'new_user_country').select('Germany')
+        expect(browser.select_list(name: 'new_user_country')).to be_selected('Germany')
+      end
     end
 
     it "returns false if the given option is not selected by label" do
@@ -239,48 +249,52 @@ describe "SelectList" do
   end
 
   describe "#select" do
-    it "selects the given item when given a String" do
-      browser.select_list(name: "new_user_country").select("Denmark")
-      expect(browser.select_list(name: "new_user_country").selected_options.map(&:text)).to eq ["Denmark"]
-    end
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
+      context "when interacting with options" do
+        it "selects the given item when given a String" do
+          browser.select_list(name: "new_user_country").select("Denmark")
+          expect(browser.select_list(name: "new_user_country").selected_options.map(&:text)).to eq ["Denmark"]
+        end
 
-    it "selects options by label" do
-      browser.select_list(name: "new_user_country").select("Germany")
-      expect(browser.select_list(name: "new_user_country").selected_options.map(&:text)).to eq ["Germany"]
-    end
+        it "selects options by label" do
+          browser.select_list(name: "new_user_country").select("Germany")
+          expect(browser.select_list(name: "new_user_country").selected_options.map(&:text)).to eq ["Germany"]
+        end
 
-    it "selects the given item when given a Regexp" do
-      browser.select_list(name: "new_user_country").select(/Denmark/)
-      expect(browser.select_list(name: "new_user_country").selected_options.map(&:text)).to eq ["Denmark"]
-    end
+        it "selects the given item when given a Regexp" do
+          browser.select_list(name: "new_user_country").select(/Denmark/)
+          expect(browser.select_list(name: "new_user_country").selected_options.map(&:text)).to eq ["Denmark"]
+        end
 
-    it "selects the given item when given an Xpath" do
-      browser.select_list(xpath: "//select[@name='new_user_country']").select("Denmark")
-      expect(browser.select_list(xpath: "//select[@name='new_user_country']").selected_options.map(&:text)).to eq ["Denmark"]
-    end
+        it "selects the given item when given an Xpath" do
+          browser.select_list(xpath: "//select[@name='new_user_country']").select("Denmark")
+          expect(browser.select_list(xpath: "//select[@name='new_user_country']").selected_options.map(&:text)).to eq ["Denmark"]
+        end
 
-    it "selects multiple items using :name and a String" do
-      browser.select_list(name: "new_user_languages").clear
-      browser.select_list(name: "new_user_languages").select("Danish")
-      browser.select_list(name: "new_user_languages").select("Swedish")
-      expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq ["Danish", "Swedish"]
-    end
+        it "selects multiple items using :name and a String" do
+          browser.select_list(name: "new_user_languages").clear
+          browser.select_list(name: "new_user_languages").select("Danish")
+          browser.select_list(name: "new_user_languages").select("Swedish")
+          expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq ["Danish", "Swedish"]
+        end
 
-    it "selects multiple items using :name and a Regexp" do
-      browser.select_list(name: "new_user_languages").clear
-      browser.select_list(name: "new_user_languages").select(/ish/)
-      expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq ["Danish", "English", "Swedish"]
-    end
+        it "selects multiple items using :name and a Regexp" do
+          browser.select_list(name: "new_user_languages").clear
+          browser.select_list(name: "new_user_languages").select(/ish/)
+          expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq ["Danish", "English", "Swedish"]
+        end
 
-    it "selects multiple items using :xpath" do
-      browser.select_list(xpath: "//select[@name='new_user_languages']").clear
-      browser.select_list(xpath: "//select[@name='new_user_languages']").select(/ish/)
-      expect(browser.select_list(xpath: "//select[@name='new_user_languages']").selected_options.map(&:text)).to eq ["Danish", "English", "Swedish"]
-    end
+        it "selects multiple items using :xpath" do
+          browser.select_list(xpath: "//select[@name='new_user_languages']").clear
+          browser.select_list(xpath: "//select[@name='new_user_languages']").select(/ish/)
+          expect(browser.select_list(xpath: "//select[@name='new_user_languages']").selected_options.map(&:text)).to eq ["Danish", "English", "Swedish"]
+        end
 
-    it "selects empty options" do
-      browser.select_list(id: "delete_user_username").select("")
-      expect(browser.select_list(id: "delete_user_username").selected_options.map(&:text)).to eq [""]
+        it "selects empty options" do
+          browser.select_list(id: "delete_user_username").select("")
+          expect(browser.select_list(id: "delete_user_username").selected_options.map(&:text)).to eq [""]
+        end
+      end
     end
 
     it "returns the value selected" do
@@ -300,13 +314,15 @@ describe "SelectList" do
       end
 
       bug "Not firing events", :phantomjs do
-        it "doesn't fire onchange event when selecting an already selected item" do
-          browser.select_list(id: "new_user_languages").clear # removes the two pre-selected options
-          browser.select_list(id: "new_user_languages").select("English")
-          expect(messages.size).to eq 3
+        bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
+          it "doesn't fire onchange event when selecting an already selected item" do
+            browser.select_list(id: "new_user_languages").clear # removes the two pre-selected options
+            browser.select_list(id: "new_user_languages").select("English")
+            expect(messages.size).to eq 3
 
-          browser.select_list(id: "new_user_languages").select("English")
-          expect(messages.size).to eq 3
+            browser.select_list(id: "new_user_languages").select("English")
+            expect(messages.size).to eq 3
+          end
         end
       end
     end
@@ -315,8 +331,10 @@ describe "SelectList" do
       expect(browser.select_list(id: "new_user_languages").select("English")).to eq "English"
     end
 
-    it "returns an empty string when selecting an option that disappears when selected" do
-      expect(browser.select_list(id: 'obsolete').select('sweden')).to eq ''
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
+      it "returns an empty string when selecting an option that disappears when selected" do
+        expect(browser.select_list(id: 'obsolete').select('sweden')).to eq ''
+      end
     end
 
     it "selects options with a single-quoted value" do
@@ -345,10 +363,12 @@ describe "SelectList" do
       expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq %w[English]
     end
 
-    it "selects the items by value regexp" do
-      browser.select_list(name: "new_user_languages").clear
-      browser.select_list(name: "new_user_languages").select_value(/1|3/)
-      expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq %w[Danish Norwegian]
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
+      it "selects the items by value regexp" do
+        browser.select_list(name: "new_user_languages").clear
+        browser.select_list(name: "new_user_languages").select_value(/1|3/)
+        expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq %w[Danish Norwegian]
+      end
     end
 
     it "raises NoValueFoundException if the option doesn't exist" do

--- a/table_nesting_spec.rb
+++ b/table_nesting_spec.rb
@@ -7,7 +7,7 @@ describe "Table" do
     browser.goto(WatirSpec.url_for("nested_tables.html"))
   end
 
-  # not a webdriver bug - IE seems unable to deal with the invalid nesting
+  # not a selenium bug - IE seems unable to deal with the invalid nesting
   not_compliant_on :internet_explorer do
     it "returns the correct number of rows under a table" do
       tables = browser.div(id: "table-rows-test").tables(id: /^tbl/)
@@ -48,6 +48,5 @@ describe "Table" do
       end
     end
   end
-
 
 end

--- a/table_spec.rb
+++ b/table_spec.rb
@@ -57,16 +57,18 @@ describe "Table" do
   end
 
   describe "#hashes" do
-    it "returns an Array of Hashes for the common table usage" do
-      expect(browser.table(id: "axis_example").hashes).to eq [
-        { "" => "March 2008",     "Before income tax" => "",       "Income tax" => "",      "After income tax" => ""      },
-        { "" => "Gregory House",  "Before income tax" => "5 934",  "Income tax" => "1 347", "After income tax" => "4 587" },
-        { "" => "Hugh Laurie",    "Before income tax" => "6 300",  "Income tax" => "1 479", "After income tax" => "4 821" },
-        { "" => "April 2008",     "Before income tax" => "",       "Income tax" => "",      "After income tax" => ""      },
-        { "" => "Gregory House",  "Before income tax" => "5 863",  "Income tax" => "1 331", "After income tax" => "4 532" },
-        { "" => "Hugh Laurie",    "Before income tax" => "6 252",  "Income tax" => "1 420", "After income tax" => "4 832" },
-        { "" => "Sum",            "Before income tax" => "24 349", "Income tax" => "5 577", "After income tax" => "18 722"},
-      ]
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
+      it "returns an Array of Hashes for the common table usage" do
+        expect(browser.table(id: "axis_example").hashes).to eq [
+          { "" => "March 2008",     "Before income tax" => "",       "Income tax" => "",      "After income tax" => ""      },
+          { "" => "Gregory House",  "Before income tax" => "5 934",  "Income tax" => "1 347", "After income tax" => "4 587" },
+          { "" => "Hugh Laurie",    "Before income tax" => "6 300",  "Income tax" => "1 479", "After income tax" => "4 821" },
+          { "" => "April 2008",     "Before income tax" => "",       "Income tax" => "",      "After income tax" => ""      },
+          { "" => "Gregory House",  "Before income tax" => "5 863",  "Income tax" => "1 331", "After income tax" => "4 532" },
+          { "" => "Hugh Laurie",    "Before income tax" => "6 252",  "Income tax" => "1 420", "After income tax" => "4 832" },
+          { "" => "Sum",            "Before income tax" => "24 349", "Income tax" => "5 577", "After income tax" => "18 722"},
+        ]
+      end
     end
 
     it "raises an error if the table could not be parsed" do

--- a/td_spec.rb
+++ b/td_spec.rb
@@ -56,9 +56,11 @@ describe "TableCell" do
   end
 
   describe "#colspan" do
-    it "gets the colspan attribute" do
-      expect(browser.td(id: 'colspan_2').colspan).to eq 2
-      expect(browser.td(id: 'no_colspan').colspan).to eq 1
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
+      it "gets the colspan attribute" do
+        expect(browser.td(id: 'colspan_2').colspan).to eq 2
+        expect(browser.td(id: 'no_colspan').colspan).to eq 1
+      end
     end
   end
 

--- a/text_field_spec.rb
+++ b/text_field_spec.rb
@@ -32,8 +32,10 @@ describe "TextField" do
       expect(browser.text_field).to exist
     end
 
-    it "respects text fields types" do
-      expect(browser.text_field.type).to eq('text')
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
+      it "respects text fields types" do
+        expect(browser.text_field.type).to eq('text')
+      end
     end
 
     it "returns true if the element exists (no type attribute)" do
@@ -112,21 +114,23 @@ describe "TextField" do
     end
   end
 
-  describe "#type" do
-    it "returns the type attribute if the text field exists" do
-      expect(browser.text_field(index: 3).type).to eq "text"
-    end
+  bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
+    describe "#type" do
+      it "returns the type attribute if the text field exists" do
+        expect(browser.text_field(index: 3).type).to eq "text"
+      end
 
-    it "returns 'text' if the type attribute is invalid" do
-      expect(browser.text_field(id: 'new_user_last_name').type).to eq "text"
-    end
+      it "returns 'text' if the type attribute is invalid" do
+        expect(browser.text_field(id: 'new_user_last_name').type).to eq "text"
+      end
 
-    it "returns 'text' if the type attribute does not exist" do
-      expect(browser.text_field(id: 'new_user_first_name').type).to eq "text"
-    end
+      it "returns 'text' if the type attribute does not exist" do
+        expect(browser.text_field(id: 'new_user_first_name').type).to eq "text"
+      end
 
-    it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(index: 1337).type }.to raise_error(Watir::Exception::UnknownObjectException)
+      it "raises UnknownObjectException if the text field doesn't exist" do
+        expect { browser.text_field(index: 1337).type }.to raise_error(Watir::Exception::UnknownObjectException)
+      end
     end
   end
 
@@ -184,9 +188,11 @@ describe "TextField" do
   end
 
   describe "#readonly?" do
-    it "returns true for read-only text fields" do
-      expect(browser.text_field(name: "new_user_code")).to be_readonly
-      expect(browser.text_field(id: "new_user_code")).to be_readonly
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1200366", :firefox do
+      it "returns true for read-only text fields" do
+        expect(browser.text_field(name: "new_user_code")).to be_readonly
+        expect(browser.text_field(id: "new_user_code")).to be_readonly
+      end
     end
 
     it "returns false for writable text fields" do
@@ -200,18 +206,24 @@ describe "TextField" do
 
   # Manipulation methods
   describe "#append" do
-    it "appends the text to the text field" do
-      browser.text_field(name: "new_user_occupation").append(" Append This")
-      expect(browser.text_field(name: "new_user_occupation").value).to eq "Developer Append This"
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
+      it "appends the text to the text field" do
+        browser.text_field(name: "new_user_occupation").append(" Append This")
+        expect(browser.text_field(name: "new_user_occupation").value).to eq "Developer Append This"
+      end
     end
 
-    it "appends multi-byte characters" do
-      browser.text_field(name: "new_user_occupation").append(" ĳĳ")
-      expect(browser.text_field(name: "new_user_occupation").value).to eq "Developer ĳĳ"
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
+      it "appends multi-byte characters" do
+        browser.text_field(name: "new_user_occupation").append(" ĳĳ")
+        expect(browser.text_field(name: "new_user_occupation").value).to eq "Developer ĳĳ"
+      end
     end
 
-    it "raises ObjectReadOnlyException if the object is read only" do
-      expect { browser.text_field(id: "new_user_code").append("Append This") }.to raise_error(Watir::Exception::ObjectReadOnlyException)
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1200366", :firefox do
+      it "raises ObjectReadOnlyException if the object is read only" do
+        expect { browser.text_field(id: "new_user_code").append("Append This") }.to raise_error(Watir::Exception::ObjectReadOnlyException)
+      end
     end
 
     it "raises ObjectDisabledException if the object is disabled" do
@@ -224,76 +236,84 @@ describe "TextField" do
   end
 
   describe "#clear" do
-    it "removes all text from the text field" do
-      browser.text_field(name: "new_user_occupation").clear
-      expect(browser.text_field(name: "new_user_occupation").value).to be_empty
-      browser.textarea(id: "delete_user_comment").clear
-      expect(browser.textarea(id: "delete_user_comment").value).to be_empty
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
+      it "removes all text from the text field" do
+        browser.text_field(name: "new_user_occupation").clear
+        expect(browser.text_field(name: "new_user_occupation").value).to be_empty
+        browser.textarea(id: "delete_user_comment").clear
+        expect(browser.textarea(id: "delete_user_comment").value).to be_empty
+      end
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
       expect { browser.text_field(id: "no_such_id").clear }.to raise_error(Watir::Exception::UnknownObjectException)
     end
 
-    it "raises ObjectReadOnlyException if the object is read only" do
-      expect { browser.text_field(id: "new_user_code").clear }.to raise_error(Watir::Exception::ObjectReadOnlyException)
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1200366", :firefox do
+      it "raises ObjectReadOnlyException if the object is read only" do
+        expect { browser.text_field(id: "new_user_code").clear }.to raise_error(Watir::Exception::ObjectReadOnlyException)
+      end
     end
   end
 
-  describe "#value=" do
-    it "sets the value of the element" do
-      browser.text_field(id: 'new_user_email').value = 'Hello Cruel World'
-      expect(browser.text_field(id: "new_user_email").value).to eq 'Hello Cruel World'
-    end
+  bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
+    describe "#value=" do
+      it "sets the value of the element" do
+        browser.text_field(id: 'new_user_email').value = 'Hello Cruel World'
+        expect(browser.text_field(id: "new_user_email").value).to eq 'Hello Cruel World'
+      end
 
-    it "is able to set multi-byte characters" do
-      browser.text_field(name: "new_user_occupation").value = "ĳĳ"
-      expect(browser.text_field(name: "new_user_occupation").value).to eq "ĳĳ"
-    end
+      it "is able to set multi-byte characters" do
+        browser.text_field(name: "new_user_occupation").value = "ĳĳ"
+        expect(browser.text_field(name: "new_user_occupation").value).to eq "ĳĳ"
+      end
 
-    it "sets the value of a textarea element" do
-      browser.textarea(id: 'delete_user_comment').value = 'Hello Cruel World'
-      expect(browser.textarea(id: "delete_user_comment").value).to eq 'Hello Cruel World'
-    end
+      it "sets the value of a textarea element" do
+        browser.textarea(id: 'delete_user_comment').value = 'Hello Cruel World'
+        expect(browser.textarea(id: "delete_user_comment").value).to eq 'Hello Cruel World'
+      end
 
-    it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(name: "no_such_name").value = 'yo' }.to raise_error(Watir::Exception::UnknownObjectException)
+      it "raises UnknownObjectException if the text field doesn't exist" do
+        expect { browser.text_field(name: "no_such_name").value = 'yo' }.to raise_error(Watir::Exception::UnknownObjectException)
+      end
     end
   end
 
-  describe "#set" do
-    it "sets the value of the element" do
-      browser.text_field(id: 'new_user_email').set('Bye Cruel World')
-      expect(browser.text_field(id: "new_user_email").value).to eq 'Bye Cruel World'
-    end
+  bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
+    describe "#set" do
+      it "sets the value of the element" do
+        browser.text_field(id: 'new_user_email').set('Bye Cruel World')
+        expect(browser.text_field(id: "new_user_email").value).to eq 'Bye Cruel World'
+      end
 
-    it "sets the value of a textarea element" do
-      browser.textarea(id: 'delete_user_comment').set('Hello Cruel World')
-      expect(browser.textarea(id: "delete_user_comment").value).to eq 'Hello Cruel World'
-    end
+      it "sets the value of a textarea element" do
+        browser.textarea(id: 'delete_user_comment').set('Hello Cruel World')
+        expect(browser.textarea(id: "delete_user_comment").value).to eq 'Hello Cruel World'
+      end
 
-    it "fires events" do
-      browser.text_field(id: "new_user_username").set("Hello World")
-      expect(browser.span(id: "current_length").text).to eq "11"
-    end
+      it "fires events" do
+        browser.text_field(id: "new_user_username").set("Hello World")
+        expect(browser.span(id: "current_length").text).to eq "11"
+      end
 
-    it "sets the value of a password field" do
-      browser.text_field(name: 'new_user_password').set('secret')
-      expect(browser.text_field(name: 'new_user_password').value).to eq 'secret'
-    end
+      it "sets the value of a password field" do
+        browser.text_field(name: 'new_user_password').set('secret')
+        expect(browser.text_field(name: 'new_user_password').value).to eq 'secret'
+      end
 
-    it "sets the value when accessed through the enclosing Form" do
-      browser.form(id: 'new_user').text_field(name: 'new_user_password').set('secret')
-      expect(browser.form(id: 'new_user').text_field(name: 'new_user_password').value).to eq 'secret'
-    end
+      it "sets the value when accessed through the enclosing Form" do
+        browser.form(id: 'new_user').text_field(name: 'new_user_password').set('secret')
+        expect(browser.form(id: 'new_user').text_field(name: 'new_user_password').value).to eq 'secret'
+      end
 
-    it "is able to set multi-byte characters" do
-      browser.text_field(name: "new_user_occupation").set("ĳĳ")
-      expect(browser.text_field(name: "new_user_occupation").value).to eq "ĳĳ"
-    end
+      it "is able to set multi-byte characters" do
+        browser.text_field(name: "new_user_occupation").set("ĳĳ")
+        expect(browser.text_field(name: "new_user_occupation").value).to eq "ĳĳ"
+      end
 
-    it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(id: "no_such_id").set('secret') }.to raise_error(Watir::Exception::UnknownObjectException)
+      it "raises UnknownObjectException if the text field doesn't exist" do
+        expect { browser.text_field(id: "no_such_id").set('secret') }.to raise_error(Watir::Exception::UnknownObjectException)
+      end
     end
   end
 end

--- a/textarea_spec.rb
+++ b/textarea_spec.rb
@@ -7,9 +7,11 @@ describe "TextArea" do
 
   let(:textarea) { browser.textarea }
 
-  it 'can set a value' do
-    textarea.set 'foo'
-    expect(textarea.value).to eq 'foo'
+  bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
+    it 'can set a value' do
+      textarea.set 'foo'
+      expect(textarea.value).to eq 'foo'
+    end
   end
 
   it 'can clear a value' do
@@ -18,9 +20,11 @@ describe "TextArea" do
     expect(textarea.value).to eq ''
   end
 
-  it 'locates textarea by value' do
-    browser.textarea.set 'foo'
-    expect(browser.textarea(value: /foo/)).to exist
-    expect(browser.textarea(value: 'foo')).to exist
+  bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
+    it 'locates textarea by value' do
+      browser.textarea.set 'foo'
+      expect(browser.textarea(value: /foo/)).to exist
+      expect(browser.textarea(value: 'foo')).to exist
+    end
   end
 end

--- a/textareas_spec.rb
+++ b/textareas_spec.rb
@@ -11,15 +11,18 @@ describe 'TextArea' do
       browser.textarea(index: 1).set 'foo2'
     end
 
-    it 'finds textareas by string' do
-      expect(browser.textareas(value: 'foo1').map(&:id)).to eq [browser.textarea(index: 0).id]
-      expect(browser.textareas(value: 'foo2').map(&:id)).to eq [browser.textarea(index: 1).id]
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
+      it 'finds textareas by string' do
+        expect(browser.textareas(value: 'foo1').map(&:id)).to eq [browser.textarea(index: 0).id]
+        expect(browser.textareas(value: 'foo2').map(&:id)).to eq [browser.textarea(index: 1).id]
+      end
     end
 
-
-    it 'finds textareas by regexp' do
-      expect(browser.textareas(value: /foo/)[0].id).to eq browser.textarea(index: 0).id
-      expect(browser.textareas(value: /foo/)[1].id).to eq browser.textarea(index: 1).id
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
+      it 'finds textareas by regexp' do
+        expect(browser.textareas(value: /foo/)[0].id).to eq browser.textarea(index: 0).id
+        expect(browser.textareas(value: /foo/)[1].id).to eq browser.textarea(index: 1).id
+      end
     end
   end
 end

--- a/window_switching_spec.rb
+++ b/window_switching_spec.rb
@@ -1,6 +1,6 @@
 require File.expand_path("../spec_helper", __FILE__)
 
-not_compliant_on :iphone, :safari do
+not_compliant_on :safari do
   describe "Browser" do
     before do
       url = WatirSpec.url_for("window_switching.html")

--- a/window_switching_spec.rb
+++ b/window_switching_spec.rb
@@ -64,14 +64,16 @@ not_compliant_on :iphone, :safari do
         expect(original_window.url).to match(/window_switching\.html/)
       end
 
-      it "it executes the given block in the window" do
-        browser.window(title: "closeable window") do
-          link = browser.a(id: "close")
-          expect(link).to exist
-          link.click
-        end.wait_while_present
+      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1223277", :firefox do
+        it "it executes the given block in the window" do
+          browser.window(title: "closeable window") do
+            link = browser.a(id: "close")
+            expect(link).to exist
+            link.click
+          end.wait_while_present
 
-        expect(browser.windows.size).to eq 1
+          expect(browser.windows.size).to eq 1
+        end
       end
 
       it "raises ArgumentError if the selector is invalid" do
@@ -105,22 +107,24 @@ not_compliant_on :iphone, :safari do
         browser.windows[1..-1].each(&:close)
       end
 
-      describe "#close" do
-        it "closes a window" do
-          browser.a(id: "open").click
-          Watir::Wait.until { browser.windows.size == 3 }
+      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1280517", :firefox do
+        describe "#close" do
+          it "closes a window" do
+            browser.a(id: "open").click
+            Watir::Wait.until { browser.windows.size == 3 }
 
-          browser.window(title: "closeable window").close
-          expect(browser.windows.size).to eq 2
-        end
+            browser.window(title: "closeable window").close
+            expect(browser.windows.size).to eq 2
+          end
 
-        it "closes the current window" do
-          browser.a(id: "open").click
-          Watir::Wait.until { browser.windows.size == 3 }
+          it "closes the current window" do
+            browser.a(id: "open").click
+            Watir::Wait.until { browser.windows.size == 3 }
 
-          window = browser.window(title: "closeable window").use
-          window.close
-          expect(browser.windows.size).to eq 2
+            window = browser.window(title: "closeable window").use
+            window.close
+            expect(browser.windows.size).to eq 2
+          end
         end
       end
 
@@ -151,7 +155,7 @@ not_compliant_on :iphone, :safari do
 
         it "does not change the current window" do
           expect(browser.title).to eq "window switching"
-          expect(browser.windows.find { |w| w.title ==  "closeable window" }).to_not be_nil
+          expect(browser.windows.find { |w| w.title == "closeable window" }).to_not be_nil
           expect(browser.title).to eq "window switching"
         end
       end
@@ -213,16 +217,16 @@ not_compliant_on :iphone, :safari do
         browser.windows[1..-1].each(&:close)
       end
 
-      describe "#exists?" do
-        it "returns false if previously referenced window is closed" do
-          window = browser.window(title: "closeable window")
-          window.use
-          browser.a(id: "close").click
-          Watir::Wait.until { browser.windows.size == 1 }
-          expect(window).to_not be_present
-        end
+      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1223277", :firefox do
+        describe "#exists?" do
+          it "returns false if previously referenced window is closed" do
+            window = browser.window(title: "closeable window")
+            window.use
+            browser.a(id: "close").click
+            Watir::Wait.until { browser.windows.size == 1 }
+            expect(window).to_not be_present
+          end
 
-        bug "https://code.google.com/p/chromedriver/issues/detail?id=950", :chrome do
           it "returns false if closed window is referenced" do
             browser.window(title: "closeable window").use
             browser.a(id: "close").click
@@ -252,84 +256,90 @@ not_compliant_on :iphone, :safari do
       end
 
       describe "#use" do
-        it "raises NoMatchingWindowFoundException error when attempting to use a referenced window that is closed" do
-          original_window = browser.window
-          browser.window(index: 1).use
-          original_window.close
-          expect { original_window.use }.to raise_error(Watir::Exception::NoMatchingWindowFoundException)
-        end
+        bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1223277", :firefox do
+          it "raises NoMatchingWindowFoundException error when attempting to use a referenced window that is closed" do
+            original_window = browser.window
+            browser.window(index: 1).use
+            original_window.close
+            expect { original_window.use }.to raise_error(Watir::Exception::NoMatchingWindowFoundException)
+          end
 
-        it "raises NoMatchingWindowFoundException error when attempting to use the current window if it is closed" do
-          browser.window(title: "closeable window").use
-          browser.a(id: "close").click
-          Watir::Wait.until { browser.windows.size == 1 }
-          expect { browser.window.use }.to raise_error(Watir::Exception::NoMatchingWindowFoundException)
+          bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1223277", :firefox do
+            it "raises NoMatchingWindowFoundException error when attempting to use the current window if it is closed" do
+              browser.window(title: "closeable window").use
+              browser.a(id: "close").click
+              Watir::Wait.until { browser.windows.size == 1 }
+              expect { browser.window.use }.to raise_error(Watir::Exception::NoMatchingWindowFoundException)
+            end
+          end
         end
       end
     end
 
-    context "with current window closed" do
-      before do
-        browser.goto WatirSpec.url_for("window_switching.html")
-        browser.a(id: "open").click
-        Watir::Wait.until { browser.windows.size == 2 }
-        browser.window(title: "closeable window").use
-        browser.a(id: "close").click
-        Watir::Wait.until { browser.windows.size == 1 }
-      end
-
-      after do
-        browser.window(index: 0).use
-        browser.windows[1..-1].each(&:close)
-      end
-
-      describe "#present?" do
-        it "should find window by index" do
-          expect(browser.window(index: 0)).to be_present
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1223277", :firefox do
+      context "with current window closed" do
+        before do
+          browser.goto WatirSpec.url_for("window_switching.html")
+          browser.a(id: "open").click
+          Watir::Wait.until { browser.windows.size == 2 }
+          browser.window(title: "closeable window").use
+          browser.a(id: "close").click
+          Watir::Wait.until { browser.windows.size == 1 }
         end
 
-        it "should find window by url" do
-          expect(browser.window(url: /window_switching\.html/)).to be_present
+        after do
+          browser.window(index: 0).use
+          browser.windows[1..-1].each(&:close)
         end
 
-        it "should find window by title" do
-          expect(browser.window(title: "window switching")).to be_present
-        end
-      end
-
-      describe "#use" do
-
-        context "switching windows without blocks" do
-          it "by index" do
-            browser.window(index: 0).use
-            expect(browser.title).to be == "window switching"
+        describe "#present?" do
+          it "should find window by index" do
+            expect(browser.window(index: 0)).to be_present
           end
 
-          it "by url" do
-            browser.window(url: /window_switching\.html/).use
-            expect(browser.title).to be == "window switching"
+          it "should find window by url" do
+            expect(browser.window(url: /window_switching\.html/)).to be_present
           end
 
-          it "by title" do
-            browser.window(title: "window switching").use
-            expect(browser.url).to match(/window_switching\.html/)
+          it "should find window by title" do
+            expect(browser.window(title: "window switching")).to be_present
           end
         end
 
-        context "Switching windows with blocks" do
-          it "by index" do
-            browser.window(index: 0).use { expect(browser.title).to be == "window switching" }
+        describe "#use" do
+
+          context "switching windows without blocks" do
+            it "by index" do
+              browser.window(index: 0).use
+              expect(browser.title).to be == "window switching"
+            end
+
+            it "by url" do
+              browser.window(url: /window_switching\.html/).use
+              expect(browser.title).to be == "window switching"
+            end
+
+            it "by title" do
+              browser.window(title: "window switching").use
+              expect(browser.url).to match(/window_switching\.html/)
+            end
           end
 
-          it "by url" do
-            browser.window(url: /window_switching\.html/).use  { expect(browser.title).to be == "window switching" }
+          context "Switching windows with blocks" do
+            it "by index" do
+              browser.window(index: 0).use { expect(browser.title).to be == "window switching" }
+            end
+
+            it "by url" do
+              browser.window(url: /window_switching\.html/).use { expect(browser.title).to be == "window switching" }
+            end
+
+            it "by title" do
+              browser.window(title: "window switching").use { expect(browser.url).to match(/window_switching\.html/) }
+            end
           end
 
-          it "by title" do
-            browser.window(title: "window switching").use { expect(browser.url).to match(/window_switching\.html/) }
-          end
         end
-
       end
     end
 
@@ -338,7 +348,7 @@ not_compliant_on :iphone, :safari do
         browser.goto WatirSpec.url_for("window_switching.html")
       end
 
-      compliant_on :firefox, :chrome do
+      compliant_on :ff_legacy, :chrome do
         it "should get the size of the current window" do
           size = browser.window.size
 
@@ -367,18 +377,20 @@ not_compliant_on :iphone, :safari do
         expect(new_size.height).to eq initial_size.height - 10
       end
 
-      bug "https://github.com/detro/ghostdriver/issues/466", :phantomjs do
-        it "should move the window" do
-          initial_pos = browser.window.position
+      not_compliant_on :firefox do
+        bug "https://github.com/detro/ghostdriver/issues/466", :phantomjs do
+          it "should move the window" do
+            initial_pos = browser.window.position
 
-          browser.window.move_to(
-            initial_pos.x + 10,
-            initial_pos.y + 10
-          )
+            browser.window.move_to(
+              initial_pos.x + 10,
+              initial_pos.y + 10
+            )
 
-          new_pos = browser.window.position
-          expect(new_pos.x).to eq initial_pos.x + 10
-          expect(new_pos.y).to eq initial_pos.y + 10
+            new_pos = browser.window.position
+            expect(new_pos.x).to eq initial_pos.x + 10
+            expect(new_pos.y).to eq initial_pos.y + 10
+          end
         end
       end
 

--- a/window_switching_spec.rb
+++ b/window_switching_spec.rb
@@ -367,14 +367,14 @@ not_compliant_on :safari do
       it "should resize the window" do
         initial_size = browser.window.size
         browser.window.resize_to(
-          initial_size.width - 10,
-          initial_size.height - 10
+          initial_size.width - 20,
+          initial_size.height - 20
         )
 
         new_size = browser.window.size
 
-        expect(new_size.width).to eq initial_size.width - 10
-        expect(new_size.height).to eq initial_size.height - 10
+        expect(new_size.width).to eq initial_size.width - 20
+        expect(new_size.height).to eq initial_size.height - 20
       end
 
       not_compliant_on :firefox do
@@ -383,18 +383,18 @@ not_compliant_on :safari do
             initial_pos = browser.window.position
 
             browser.window.move_to(
-              initial_pos.x + 10,
-              initial_pos.y + 10
+              initial_pos.x + 2,
+              initial_pos.y + 2
             )
 
             new_pos = browser.window.position
-            expect(new_pos.x).to eq initial_pos.x + 10
-            expect(new_pos.y).to eq initial_pos.y + 10
+            expect(new_pos.x).to eq initial_pos.x + 2
+            expect(new_pos.y).to eq initial_pos.y + 2
           end
         end
       end
 
-      compliant_on %i(firefox window_manager) do
+      compliant_on :window_manager do
         it "should maximize the window" do
           initial_size = browser.window.size
 
@@ -408,5 +408,4 @@ not_compliant_on :safari do
       end
     end
   end
-
 end


### PR DESCRIPTION
These guards are necessary for use with Selenium 3.0 since default firefox uses geckodriver