### PR TITLE
change default from assert_exists to when_present for actions

### DIFF
--- a/alert_spec.rb
+++ b/alert_spec.rb
@@ -42,7 +42,7 @@ describe 'Alert API' do
           describe '#close' do
             it 'closes alert' do
               browser.button(id: 'alert').click
-              browser.alert.when_present.close
+              browser.alert.close
               expect(browser.alert).to_not exist
             end
           end
@@ -76,7 +76,7 @@ describe 'Alert API' do
         describe '#close' do
           it 'cancels confirm' do
             browser.button(id: 'confirm').click
-            browser.alert.when_present.close
+            browser.alert.close
             expect(browser.button(id: 'confirm').value).to eq "false"
           end
         end

--- a/alert_spec.rb
+++ b/alert_spec.rb
@@ -26,7 +26,7 @@ describe 'Alert API' do
 
           it 'returns true if alert is present' do
             browser.button(id: 'alert').click
-            browser.wait_until(10) { browser.alert.exists? }
+            browser.wait_until(timeout: 10) { browser.alert.exists? }
           end
         end
 
@@ -45,21 +45,6 @@ describe 'Alert API' do
               browser.alert.close
               expect(browser.alert).to_not exist
             end
-          end
-        end
-
-        describe 'when_present' do
-          it 'waits until alert is present and goes on' do
-            browser.button(id: 'timeout-alert').click
-            browser.alert.when_present.ok
-
-            expect(browser.alert).to_not exist
-          end
-
-          it 'raises error if alert is not present after timeout' do
-            expect {
-              browser.alert.when_present(0.1).ok
-            }.to raise_error(Watir::Wait::TimeoutError)
           end
         end
       end

--- a/area_spec.rb
+++ b/area_spec.rb
@@ -62,8 +62,8 @@ describe "Area" do
     end
 
     it "raises UnknownObjectException if the area doesn't exist" do
-      expect { browser.area(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.area(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.area(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.area(index: 1337).id }.to raise_unknown_object_exception
     end
 
   end

--- a/browser_spec.rb
+++ b/browser_spec.rb
@@ -286,7 +286,7 @@ describe "Browser" do
 
   it "raises UnknownObjectException when trying to access DOM elements on plain/text-page" do
     browser.goto(WatirSpec.url_for("plain_text", needs_server: true))
-    expect { browser.div(id: 'foo').id }.to raise_error(Watir::Exception::UnknownObjectException)
+    expect { browser.div(id: 'foo').id }.to raise_unknown_object_exception
   end
 
 end

--- a/button_spec.rb
+++ b/button_spec.rb
@@ -263,7 +263,7 @@ describe "Button" do
     end
 
     it "raises ObjectDisabledException when clicking a disabled button" do
-      expect { browser.button(value: "Disabled").click }.to raise_error(Watir::Exception::ObjectDisabledException)
+      expect { browser.button(value: "Disabled").click }.to raise_object_disabled_exception
     end
   end
 

--- a/button_spec.rb
+++ b/button_spec.rb
@@ -105,7 +105,7 @@ describe "Button" do
     end
 
     it "raises UnknownObjectException if button does not exist" do
-      expect { browser.button(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.button(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -117,7 +117,7 @@ describe "Button" do
     end
 
     it "raises UnknownObjectException if the button does not exist" do
-      expect { browser.button(name: "no_such_name").name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.button(name: "no_such_name").name }.to raise_unknown_object_exception
     end
   end
 
@@ -128,7 +128,7 @@ describe "Button" do
     end
 
     it "raises UnknownObjectException if the button does not exist" do
-      expect { browser.button(name: "no_such_name").src }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.button(name: "no_such_name").src }.to raise_unknown_object_exception
     end
   end
 
@@ -150,7 +150,7 @@ describe "Button" do
     end
 
     it "raises UnknownObjectException if the button does not exist" do
-      expect { browser.button(name: "no_such_name").style }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.button(name: "no_such_name").style }.to raise_unknown_object_exception
     end
   end
 
@@ -172,7 +172,7 @@ describe "Button" do
     end
 
     it "raises UnknownObjectException if button does not exist" do
-      expect { browser.button(name: "no_such_name").type }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.button(name: "no_such_name").type }.to raise_unknown_object_exception
     end
   end
 
@@ -184,7 +184,7 @@ describe "Button" do
     end
 
     it "raises UnknownObjectException if button does not exist" do
-      expect { browser.button(name: "no_such_name").value }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.button(name: "no_such_name").value }.to raise_unknown_object_exception
     end
   end
 
@@ -197,7 +197,7 @@ describe "Button" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.button(id: "no_such_id").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.button(id: "no_such_id").text }.to raise_unknown_object_exception
     end
   end
 
@@ -225,7 +225,7 @@ describe "Button" do
     end
 
     it "raises UnknownObjectException if the button doesn't exist" do
-      expect { browser.button(name: "no_such_name").enabled? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.button(name: "no_such_name").enabled? }.to raise_unknown_object_exception
     end
   end
 
@@ -239,7 +239,7 @@ describe "Button" do
     end
 
     it "raises UnknownObjectException if button does not exist" do
-      expect { browser.button(name: "no_such_name").disabled? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.button(name: "no_such_name").disabled? }.to raise_unknown_object_exception
     end
   end
 
@@ -258,8 +258,8 @@ describe "Button" do
     end
 
     it "raises UnknownObjectException when clicking a button that doesn't exist" do
-      expect { browser.button(value: "no_such_value").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.button(id: "no_such_id").click }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.button(value: "no_such_value").click }.to raise_unknown_object_exception
+      expect { browser.button(id: "no_such_id").click }.to raise_unknown_object_exception
     end
 
     it "raises ObjectDisabledException when clicking a disabled button" do

--- a/checkbox_spec.rb
+++ b/checkbox_spec.rb
@@ -87,7 +87,7 @@ describe "CheckBox" do
     end
 
     it "raises UnknownObjectException if the checkbox doesn't exist" do
-      expect { browser.checkbox(id: "no_such_id").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.checkbox(id: "no_such_id").class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -101,7 +101,7 @@ describe "CheckBox" do
     end
 
     it "raises UnknownObjectException if the checkbox doesn't exist" do
-      expect { browser.checkbox(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.checkbox(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -115,7 +115,7 @@ describe "CheckBox" do
     end
 
     it "raises UnknownObjectException if the checkbox doesn't exist" do
-      expect { browser.checkbox(index: 1337).name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.checkbox(index: 1337).name }.to raise_unknown_object_exception
     end
   end
 
@@ -129,7 +129,7 @@ describe "CheckBox" do
     end
 
     it "raises UnknownObjectException if the checkbox doesn't exist" do
-      expect { browser.checkbox(index: 1337).title }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.checkbox(index: 1337).title }.to raise_unknown_object_exception
     end
   end
 
@@ -139,7 +139,7 @@ describe "CheckBox" do
     end
 
     it "raises UnknownObjectException if the checkbox doesn't exist" do
-      expect { browser.checkbox(index: 1337).type }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.checkbox(index: 1337).type }.to raise_unknown_object_exception
     end
   end
 
@@ -149,7 +149,7 @@ describe "CheckBox" do
     end
 
     it "raises UnknownObjectException if the checkbox doesn't exist" do
-      expect { browser.checkbox(index: 1337).value}.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.checkbox(index: 1337).value}.to raise_unknown_object_exception
     end
   end
 
@@ -178,8 +178,8 @@ describe "CheckBox" do
     end
 
     it "raises UnknownObjectException if the checkbox button doesn't exist" do
-      expect { browser.checkbox(id: "no_such_id").enabled?  }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.checkbox(xpath: "//input[@id='no_such_id']").enabled?  }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.checkbox(id: "no_such_id").enabled?  }.to raise_unknown_object_exception
+      expect { browser.checkbox(xpath: "//input[@id='no_such_id']").enabled?  }.to raise_unknown_object_exception
     end
   end
 
@@ -193,7 +193,7 @@ describe "CheckBox" do
     end
 
     it "raises UnknownObjectException if the checkbox doesn't exist" do
-      expect { browser.checkbox(index: 1337).disabled? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.checkbox(index: 1337).disabled? }.to raise_unknown_object_exception
     end
   end
 
@@ -217,8 +217,8 @@ describe "CheckBox" do
     end
 
     it "raises UnknownObjectException if the checkbox button doesn't exist" do
-      expect { browser.checkbox(name: "no_such_id").clear }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.checkbox(xpath: "//input[@id='no_such_id']").clear  }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.checkbox(name: "no_such_id").clear }.to raise_unknown_object_exception
+      expect { browser.checkbox(xpath: "//input[@id='no_such_id']").clear  }.to raise_unknown_object_exception
     end
   end
 
@@ -242,8 +242,8 @@ describe "CheckBox" do
     end
 
     it "raises UnknownObjectException if the checkbox button doesn't exist" do
-      expect { browser.checkbox(name: "no_such_name").set  }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.checkbox(xpath: "//input[@name='no_such_name']").set  }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.checkbox(name: "no_such_name").set  }.to raise_unknown_object_exception
+      expect { browser.checkbox(xpath: "//input[@name='no_such_name']").set  }.to raise_unknown_object_exception
     end
 
     it "raises ObjectDisabledException if the checkbox is disabled" do
@@ -272,8 +272,8 @@ describe "CheckBox" do
     end
 
     it "raises UnknownObjectException if the checkbox button doesn't exist" do
-      expect { browser.checkbox(id: "no_such_id").set?  }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.checkbox(xpath: "//input[@id='no_such_id']").set?  }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.checkbox(id: "no_such_id").set?  }.to raise_unknown_object_exception
+      expect { browser.checkbox(xpath: "//input[@id='no_such_id']").set?  }.to raise_unknown_object_exception
     end
   end
 

--- a/checkbox_spec.rb
+++ b/checkbox_spec.rb
@@ -202,8 +202,8 @@ describe "CheckBox" do
   describe "#clear" do
     it "raises ObjectDisabledException if the checkbox is disabled" do
       expect(browser.checkbox(id: "new_user_interests_dentistry")).to_not be_set
-      expect { browser.checkbox(id: "new_user_interests_dentistry").clear }.to raise_error(Watir::Exception::ObjectDisabledException)
-      expect { browser.checkbox(xpath: "//input[@id='new_user_interests_dentistry']").clear }.to raise_error(Watir::Exception::ObjectDisabledException)
+      expect { browser.checkbox(id: "new_user_interests_dentistry").clear }.to raise_object_disabled_exception
+      expect { browser.checkbox(xpath: "//input[@id='new_user_interests_dentistry']").clear }.to raise_object_disabled_exception
     end
 
     it "clears the checkbox button if it is set" do
@@ -247,8 +247,8 @@ describe "CheckBox" do
     end
 
     it "raises ObjectDisabledException if the checkbox is disabled" do
-      expect { browser.checkbox(id: "new_user_interests_dentistry").set  }.to raise_error(Watir::Exception::ObjectDisabledException)
-      expect { browser.checkbox(xpath: "//input[@id='new_user_interests_dentistry']").set  }.to raise_error(Watir::Exception::ObjectDisabledException )
+      expect { browser.checkbox(id: "new_user_interests_dentistry").set  }.to raise_object_disabled_exception
+      expect { browser.checkbox(xpath: "//input[@id='new_user_interests_dentistry']").set  }.to raise_object_disabled_exception
     end
   end
 

--- a/dd_spec.rb
+++ b/dd_spec.rb
@@ -44,10 +44,10 @@ describe "Dd" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.dd(id: "no_such_id").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dd(title: "no_such_title").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dd(index: 1337).class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dd(xpath: "//dd[@id='no_such_id']").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.dd(id: "no_such_id").class_name }.to raise_unknown_object_exception
+      expect { browser.dd(title: "no_such_title").class_name }.to raise_unknown_object_exception
+      expect { browser.dd(index: 1337).class_name }.to raise_unknown_object_exception
+      expect { browser.dd(xpath: "//dd[@id='no_such_id']").class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -61,9 +61,9 @@ describe "Dd" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect {browser.dd(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect {browser.dd(title: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect {browser.dd(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect {browser.dd(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect {browser.dd(title: "no_such_id").id }.to raise_unknown_object_exception
+      expect {browser.dd(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -83,10 +83,10 @@ describe "Dd" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.dd(id: "no_such_id").text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dd(title: "no_such_title").text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dd(index: 1337).text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dd(xpath: "//dd[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.dd(id: "no_such_id").text }.to raise_unknown_object_exception
+      expect { browser.dd(title: "no_such_title").text }.to raise_unknown_object_exception
+      expect { browser.dd(index: 1337).text }.to raise_unknown_object_exception
+      expect { browser.dd(xpath: "//dd[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 
@@ -109,10 +109,10 @@ describe "Dd" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.dd(id: "no_such_id").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dd(title: "no_such_title").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dd(index: 1337).click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dd(xpath: "//dd[@id='no_such_id']").click }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.dd(id: "no_such_id").click }.to raise_unknown_object_exception
+      expect { browser.dd(title: "no_such_title").click }.to raise_unknown_object_exception
+      expect { browser.dd(index: 1337).click }.to raise_unknown_object_exception
+      expect { browser.dd(xpath: "//dd[@id='no_such_id']").click }.to raise_unknown_object_exception
     end
   end
 

--- a/del_spec.rb
+++ b/del_spec.rb
@@ -55,7 +55,7 @@ describe "Del" do
     end
 
     it "raises UnknownObjectException if the del doesn't exist" do
-      expect { browser.del(id: 'no_such_id').class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.del(id: 'no_such_id').class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -69,8 +69,8 @@ describe "Del" do
     end
 
     it "raises UnknownObjectException if the del doesn't exist" do
-      expect { browser.del(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.del(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.del(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.del(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -84,8 +84,8 @@ describe "Del" do
     end
 
     it "raises UnknownObjectException if the del doesn't exist" do
-      expect { browser.del(id: 'no_such_id').title }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.del(xpath: "//del[@id='no_such_id']").title }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.del(id: 'no_such_id').title }.to raise_unknown_object_exception
+      expect { browser.del(xpath: "//del[@id='no_such_id']").title }.to raise_unknown_object_exception
     end
   end
 
@@ -99,8 +99,8 @@ describe "Del" do
     end
 
     it "raises UnknownObjectException if the del doesn't exist" do
-      expect { browser.del(id: 'no_such_id').text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.del(:xpath , "//del[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.del(id: 'no_such_id').text }.to raise_unknown_object_exception
+      expect { browser.del(:xpath , "//del[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 
@@ -122,8 +122,8 @@ describe "Del" do
     end
 
     it "raises UnknownObjectException if the del doesn't exist" do
-      expect { browser.del(id: "no_such_id").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.del(title: "no_such_title").click }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.del(id: "no_such_id").click }.to raise_unknown_object_exception
+      expect { browser.del(title: "no_such_title").click }.to raise_unknown_object_exception
     end
   end
 end

--- a/div_spec.rb
+++ b/div_spec.rb
@@ -60,10 +60,10 @@ describe "Div" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.div(id: "no_such_id").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.div(title: "no_such_title").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.div(index: 1337).class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.div(xpath: "//div[@id='no_such_id']").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.div(id: "no_such_id").class_name }.to raise_unknown_object_exception
+      expect { browser.div(title: "no_such_title").class_name }.to raise_unknown_object_exception
+      expect { browser.div(index: 1337).class_name }.to raise_unknown_object_exception
+      expect { browser.div(xpath: "//div[@id='no_such_id']").class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -77,9 +77,9 @@ describe "Div" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.div(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.div(title: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.div(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.div(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.div(title: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.div(index: 1337).id }.to raise_unknown_object_exception
     end
 
     it "should take all conditions into account when locating by id" do
@@ -100,7 +100,7 @@ describe "Div" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect {browser.div(id: "no_such_id").style }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect {browser.div(id: "no_such_id").style }.to raise_unknown_object_exception
     end
   end
 
@@ -120,10 +120,10 @@ describe "Div" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.div(id: "no_such_id").text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.div(title: "no_such_title").text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.div(index: 1337).text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.div(xpath: "//div[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.div(id: "no_such_id").text }.to raise_unknown_object_exception
+      expect { browser.div(title: "no_such_title").text }.to raise_unknown_object_exception
+      expect { browser.div(index: 1337).text }.to raise_unknown_object_exception
+      expect { browser.div(xpath: "//div[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 
@@ -145,10 +145,10 @@ describe "Div" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.div(id: "no_such_id").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.div(title: "no_such_title").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.div(index: 1337).click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.div(xpath: "//div[@id='no_such_id']").click }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.div(id: "no_such_id").click }.to raise_unknown_object_exception
+      expect { browser.div(title: "no_such_title").click }.to raise_unknown_object_exception
+      expect { browser.div(index: 1337).click }.to raise_unknown_object_exception
+      expect { browser.div(xpath: "//div[@id='no_such_id']").click }.to raise_unknown_object_exception
     end
   end
 

--- a/dl_spec.rb
+++ b/dl_spec.rb
@@ -44,10 +44,10 @@ describe "Dl" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.dl(id: "no_such_id").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dl(title: "no_such_title").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dl(index: 1337).class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dl(xpath: "//dl[@id='no_such_id']").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.dl(id: "no_such_id").class_name }.to raise_unknown_object_exception
+      expect { browser.dl(title: "no_such_title").class_name }.to raise_unknown_object_exception
+      expect { browser.dl(index: 1337).class_name }.to raise_unknown_object_exception
+      expect { browser.dl(xpath: "//dl[@id='no_such_id']").class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -61,9 +61,9 @@ describe "Dl" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect {browser.dl(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect {browser.dl(title: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect {browser.dl(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect {browser.dl(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect {browser.dl(title: "no_such_id").id }.to raise_unknown_object_exception
+      expect {browser.dl(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -83,10 +83,10 @@ describe "Dl" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.dl(id: "no_such_id").text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dl(title: "no_such_title").text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dl(index: 1337).text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dl(xpath: "//dl[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.dl(id: "no_such_id").text }.to raise_unknown_object_exception
+      expect { browser.dl(title: "no_such_title").text }.to raise_unknown_object_exception
+      expect { browser.dl(index: 1337).text }.to raise_unknown_object_exception
+      expect { browser.dl(xpath: "//dl[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 
@@ -109,10 +109,10 @@ describe "Dl" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.dl(id: "no_such_id").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dl(title: "no_such_title").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dl(index: 1337).click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dl(xpath: "//dl[@id='no_such_id']").click }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.dl(id: "no_such_id").click }.to raise_unknown_object_exception
+      expect { browser.dl(title: "no_such_title").click }.to raise_unknown_object_exception
+      expect { browser.dl(index: 1337).click }.to raise_unknown_object_exception
+      expect { browser.dl(xpath: "//dl[@id='no_such_id']").click }.to raise_unknown_object_exception
     end
   end
 

--- a/dt_spec.rb
+++ b/dt_spec.rb
@@ -44,10 +44,10 @@ describe "Dt" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.dt(id: "no_such_id").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dt(title: "no_such_title").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dt(index: 1337).class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dt(xpath: "//dt[@id='no_such_id']").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.dt(id: "no_such_id").class_name }.to raise_unknown_object_exception
+      expect { browser.dt(title: "no_such_title").class_name }.to raise_unknown_object_exception
+      expect { browser.dt(index: 1337).class_name }.to raise_unknown_object_exception
+      expect { browser.dt(xpath: "//dt[@id='no_such_id']").class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -61,9 +61,9 @@ describe "Dt" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect {browser.dt(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect {browser.dt(title: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect {browser.dt(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect {browser.dt(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect {browser.dt(title: "no_such_id").id }.to raise_unknown_object_exception
+      expect {browser.dt(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -83,10 +83,10 @@ describe "Dt" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.dt(id: "no_such_id").text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dt(title: "no_such_title").text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dt(index: 1337).text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dt(xpath: "//dt[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.dt(id: "no_such_id").text }.to raise_unknown_object_exception
+      expect { browser.dt(title: "no_such_title").text }.to raise_unknown_object_exception
+      expect { browser.dt(index: 1337).text }.to raise_unknown_object_exception
+      expect { browser.dt(xpath: "//dt[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 
@@ -109,10 +109,10 @@ describe "Dt" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.dt(id: "no_such_id").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dt(title: "no_such_title").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dt(index: 1337).click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dt(xpath: "//dt[@id='no_such_id']").click }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.dt(id: "no_such_id").click }.to raise_unknown_object_exception
+      expect { browser.dt(title: "no_such_title").click }.to raise_unknown_object_exception
+      expect { browser.dt(index: 1337).click }.to raise_unknown_object_exception
+      expect { browser.dt(xpath: "//dt[@id='no_such_id']").click }.to raise_unknown_object_exception
     end
   end
 

--- a/element_spec.rb
+++ b/element_spec.rb
@@ -105,7 +105,7 @@ describe "Element" do
     end
 
     it "finds several elements from an element's subtree" do
-      expect(browser.fieldset.elements(xpath: ".//label").length).to eq 20
+      expect(browser.fieldset.elements(xpath: ".//label").length).to eq 21
     end
   end
 

--- a/element_spec.rb
+++ b/element_spec.rb
@@ -14,7 +14,7 @@ describe "Element" do
     end
 
     it "raises UnknownObjectException with a sane error message when given a hash of :how => 'what' arguments (non-existing object)" do
-      expect { browser.text_field(index: 100, name: "foo").id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(index: 100, name: "foo").id }.to raise_unknown_object_exception
     end
 
     it "raises ArgumentError if given the wrong number of arguments" do
@@ -195,7 +195,7 @@ describe "Element" do
     end
 
     it "raises UnknownObjectException exception if the element does not exist" do
-      expect {browser.text_field(id: "no_such_id").visible?}.to raise_error(Watir::Exception::UnknownObjectException)
+      expect {browser.text_field(id: "no_such_id").visible?}.to raise_unknown_object_exception
     end
 
     it "raises UnknownObjectException exception if the element is stale" do
@@ -205,7 +205,7 @@ describe "Element" do
       allow(browser.driver).to receive(:find_element).with(:id, 'new_user_email') { wd_element }
       browser.refresh
 
-      expect { browser.text_field(id: 'new_user_email').visible? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(id: 'new_user_email').visible? }.to raise_unknown_object_exception
     end
 
     it "returns true if the element has style='visibility: visible' even if parent has style='visibility: hidden'" do

--- a/em_spec.rb
+++ b/em_spec.rb
@@ -40,10 +40,10 @@ describe "Em" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.em(id: "no_such_id").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.em(title: "no_such_title").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.em(index: 1337).class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.em(xpath: "//em[@id='no_such_id']").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.em(id: "no_such_id").class_name }.to raise_unknown_object_exception
+      expect { browser.em(title: "no_such_title").class_name }.to raise_unknown_object_exception
+      expect { browser.em(index: 1337).class_name }.to raise_unknown_object_exception
+      expect { browser.em(xpath: "//em[@id='no_such_id']").class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -53,9 +53,9 @@ describe "Em" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect {browser.em(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect {browser.em(title: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect {browser.em(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect {browser.em(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect {browser.em(title: "no_such_id").id }.to raise_unknown_object_exception
+      expect {browser.em(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -71,10 +71,10 @@ describe "Em" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.em(id: "no_such_id").text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.em(title: "no_such_title").text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.em(index: 1337).text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.em(xpath: "//em[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.em(id: "no_such_id").text }.to raise_unknown_object_exception
+      expect { browser.em(title: "no_such_title").text }.to raise_unknown_object_exception
+      expect { browser.em(index: 1337).text }.to raise_unknown_object_exception
+      expect { browser.em(xpath: "//em[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 
@@ -91,10 +91,10 @@ describe "Em" do
   # Manipulation methods
   describe "#click" do
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.em(id: "no_such_id").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.em(title: "no_such_title").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.em(index: 1337).click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.em(xpath: "//em[@id='no_such_id']").click }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.em(id: "no_such_id").click }.to raise_unknown_object_exception
+      expect { browser.em(title: "no_such_title").click }.to raise_unknown_object_exception
+      expect { browser.em(index: 1337).click }.to raise_unknown_object_exception
+      expect { browser.em(xpath: "//em[@id='no_such_id']").click }.to raise_unknown_object_exception
     end
   end
 

--- a/filefield_spec.rb
+++ b/filefield_spec.rb
@@ -55,7 +55,7 @@ describe "FileField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.file_field(index: 1337).class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.file_field(index: 1337).class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -65,7 +65,7 @@ describe "FileField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.file_field(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.file_field(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -75,7 +75,7 @@ describe "FileField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.file_field(index: 1337).name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.file_field(index: 1337).name }.to raise_unknown_object_exception
     end
   end
 
@@ -91,7 +91,7 @@ describe "FileField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.file_field(index: 1337).type }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.file_field(index: 1337).type }.to raise_unknown_object_exception
     end
   end
 

--- a/frame_spec.rb
+++ b/frame_spec.rb
@@ -73,19 +73,19 @@ describe "Frame" do
   end
 
   it "raises UnknownFrameException when accessing elements inside non-existing frame" do
-    expect { browser.frame(name: "no_such_name").p(index: 0).id }.to raise_error(Watir::Exception::UnknownFrameException)
+    expect { browser.frame(name: "no_such_name").p(index: 0).id }.to raise_unknown_frame_exception
   end
 
   it "raises UnknownFrameException when accessing a non-existing frame" do
-    expect { browser.frame(name: "no_such_name").id }.to raise_error(Watir::Exception::UnknownFrameException)
+    expect { browser.frame(name: "no_such_name").id }.to raise_unknown_frame_exception
   end
 
   it "raises UnknownFrameException when accessing a non-existing subframe" do
-    expect { browser.frame(name: "frame1").frame(name: "no_such_name").id }.to raise_error(Watir::Exception::UnknownFrameException)
+    expect { browser.frame(name: "frame1").frame(name: "no_such_name").id }.to raise_unknown_frame_exception
   end
 
   it "raises UnknownObjectException when accessing a non-existing element inside an existing frame" do
-    expect { browser.frame(index: 0).p(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+    expect { browser.frame(index: 0).p(index: 1337).id }.to raise_unknown_object_exception
   end
 
   it "raises NoMethodError when trying to access attributes it doesn't have" do

--- a/hidden_spec.rb
+++ b/hidden_spec.rb
@@ -57,7 +57,7 @@ describe "Hidden" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.hidden(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.hidden(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -67,7 +67,7 @@ describe "Hidden" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.hidden(index: 1337).name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.hidden(index: 1337).name }.to raise_unknown_object_exception
     end
   end
 
@@ -77,7 +77,7 @@ describe "Hidden" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.hidden(index: 1337).type }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.hidden(index: 1337).type }.to raise_unknown_object_exception
     end
   end
 
@@ -87,7 +87,7 @@ describe "Hidden" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.hidden(index: 1337).value }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.hidden(index: 1337).value }.to raise_unknown_object_exception
     end
   end
 

--- a/hn_spec.rb
+++ b/hn_spec.rb
@@ -52,7 +52,7 @@ describe ["H1", "H2", "H3", "H4", "H5", "H6"] do
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      expect { browser.h2(id: 'no_such_id').class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.h2(id: 'no_such_id').class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -66,8 +66,8 @@ describe ["H1", "H2", "H3", "H4", "H5", "H6"] do
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      expect { browser.h1(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.h1(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.h1(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.h1(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -81,8 +81,8 @@ describe ["H1", "H2", "H3", "H4", "H5", "H6"] do
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      expect { browser.h1(id: 'no_such_id').text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.h1(:xpath , "//h1[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.h1(id: 'no_such_id').text }.to raise_unknown_object_exception
+      expect { browser.h1(:xpath , "//h1[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 

--- a/html/forms_with_input_elements.html
+++ b/html/forms_with_input_elements.html
@@ -43,6 +43,8 @@
             <input type="text" name="new_user_species" id="new_user_species" value="Homo sapiens sapiens" disabled="disabled" /> <br />
             <label for="new_user_code">Personal code</label>
             <input type="text" title="Your personal code" name="new_user_code" id="new_user_code" value="HE2FF8" readonly="readonly" /> <br  />
+            <label for="good_luck">Good Luck</label>
+            <input type="text" title="Good Luck" name="good_luck" id="good_luck" disabled="disabled" readonly="readonly" /> <br  />
             <input type="col" id="unknown_text_field" /> <br />
             <label for="new_user_languages">Languages</label>
             <select name="new_user_languages" id="new_user_languages" multiple="multiple" onchange="WatirSpec.addMessage('changed language');">

--- a/html/wait.html
+++ b/html/wait.html
@@ -38,6 +38,8 @@
         show and enable btn
       </a>
     </div>
-    <div id="also_hidden" style="display:block;"></div>
+    <div id="also_hidden" style="display:none;">
+      <div id="hidden_child">Nothing to see here</div>
+    </div>
   </body>
 </html>

--- a/iframe_spec.rb
+++ b/iframe_spec.rb
@@ -123,19 +123,19 @@ describe "IFrame" do
   end
 
   it "raises UnknownFrameException when accessing elements inside non-existing iframe" do
-    expect { browser.iframe(name: "no_such_name").p(index: 0).id }.to raise_error(Watir::Exception::UnknownFrameException)
+    expect { browser.iframe(name: "no_such_name").p(index: 0).id }.to raise_unknown_frame_exception
   end
 
   it "raises UnknownFrameException when accessing a non-existing iframe" do
-    expect { browser.iframe(name: "no_such_name").id }.to raise_error(Watir::Exception::UnknownFrameException)
+    expect { browser.iframe(name: "no_such_name").id }.to raise_unknown_frame_exception
   end
 
   it "raises UnknownFrameException when accessing a non-existing subframe" do
-    expect { browser.iframe(name: "iframe1").iframe(name: "no_such_name").id }.to raise_error(Watir::Exception::UnknownFrameException)
+    expect { browser.iframe(name: "iframe1").iframe(name: "no_such_name").id }.to raise_unknown_frame_exception
   end
 
   it "raises UnknownObjectException when accessing a non-existing element inside an existing iframe" do
-    expect { browser.iframe(index: 0).p(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+    expect { browser.iframe(index: 0).p(index: 1337).id }.to raise_unknown_object_exception
   end
 
   it "raises NoMethodError when trying to access attributes it doesn't have" do

--- a/image_spec.rb
+++ b/image_spec.rb
@@ -55,7 +55,7 @@ describe "Image" do
     end
 
     it "raises UnknownObjectException if the image doesn't exist" do
-      expect { browser.image(index: 1337).alt }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.image(index: 1337).alt }.to raise_unknown_object_exception
     end
   end
 
@@ -69,7 +69,7 @@ describe "Image" do
     end
 
     it "raises UnknownObjectException if the image doesn't exist" do
-      expect { browser.image(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.image(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -83,7 +83,7 @@ describe "Image" do
     end
 
     it "raises UnknownObjectException if the image doesn't exist" do
-      expect { browser.image(index: 1337).src }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.image(index: 1337).src }.to raise_unknown_object_exception
     end
   end
 
@@ -97,7 +97,7 @@ describe "Image" do
     end
 
     it "raises UnknownObjectException if the image doesn't exist" do
-      expect { browser.image(index: 1337).title }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.image(index: 1337).title }.to raise_unknown_object_exception
     end
   end
 
@@ -113,10 +113,10 @@ describe "Image" do
   # Manipulation methods
   describe "#click" do
     it "raises UnknownObjectException when the image doesn't exist" do
-      expect { browser.image(id: 'missing_attribute').click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.image(class: 'missing_attribute').click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.image(src: 'missing_attribute').click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.image(alt: 'missing_attribute').click }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.image(id: 'missing_attribute').click }.to raise_unknown_object_exception
+      expect { browser.image(class: 'missing_attribute').click }.to raise_unknown_object_exception
+      expect { browser.image(src: 'missing_attribute').click }.to raise_unknown_object_exception
+      expect { browser.image(alt: 'missing_attribute').click }.to raise_unknown_object_exception
     end
   end
 
@@ -126,7 +126,7 @@ describe "Image" do
     end
 
     it "raises UnknownObjectException if the image doesn't exist" do
-      expect { browser.image(index: 1337).height }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.image(index: 1337).height }.to raise_unknown_object_exception
     end
   end
 
@@ -136,7 +136,7 @@ describe "Image" do
     end
 
     it "raises UnknownObjectException if the image doesn't exist" do
-      expect { browser.image(index: 1337).width }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.image(index: 1337).width }.to raise_unknown_object_exception
     end
   end
 
@@ -154,10 +154,10 @@ describe "Image" do
       end
 
       it "raises UnknownObjectException if the image doesn't exist" do
-        expect { browser.image(id: 'no_such_image').loaded? }.to raise_error(Watir::Exception::UnknownObjectException)
-        expect { browser.image(src: 'no_such_image').loaded? }.to raise_error(Watir::Exception::UnknownObjectException)
-        expect { browser.image(alt: 'no_such_image').loaded? }.to raise_error(Watir::Exception::UnknownObjectException)
-        expect { browser.image(index: 1337).loaded? }.to raise_error(Watir::Exception::UnknownObjectException)
+        expect { browser.image(id: 'no_such_image').loaded? }.to raise_unknown_object_exception
+        expect { browser.image(src: 'no_such_image').loaded? }.to raise_unknown_object_exception
+        expect { browser.image(alt: 'no_such_image').loaded? }.to raise_unknown_object_exception
+        expect { browser.image(index: 1337).loaded? }.to raise_unknown_object_exception
       end
     end
   end

--- a/ins_spec.rb
+++ b/ins_spec.rb
@@ -55,7 +55,7 @@ describe "Ins" do
     end
 
     it "raises UnknownObjectException if the ins doesn't exist" do
-      expect { browser.ins(id: 'no_such_id').class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.ins(id: 'no_such_id').class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -69,8 +69,8 @@ describe "Ins" do
     end
 
     it "raises UnknownObjectException if the ins doesn't exist" do
-      expect { browser.ins(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.ins(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.ins(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.ins(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -84,8 +84,8 @@ describe "Ins" do
     end
 
     it "raises UnknownObjectException if the ins doesn't exist" do
-      expect { browser.ins(id: 'no_such_id').title }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.ins(xpath: "//ins[@id='no_such_id']").title }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.ins(id: 'no_such_id').title }.to raise_unknown_object_exception
+      expect { browser.ins(xpath: "//ins[@id='no_such_id']").title }.to raise_unknown_object_exception
     end
   end
 
@@ -99,8 +99,8 @@ describe "Ins" do
     end
 
     it "raises UnknownObjectException if the ins doesn't exist" do
-      expect { browser.ins(id: 'no_such_id').text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.ins(:xpath , "//ins[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.ins(id: 'no_such_id').text }.to raise_unknown_object_exception
+      expect { browser.ins(:xpath , "//ins[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 
@@ -122,8 +122,8 @@ describe "Ins" do
     end
 
     it "raises UnknownObjectException if the ins doesn't exist" do
-      expect { browser.ins(id: "no_such_id").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.ins(title: "no_such_title").click }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.ins(id: "no_such_id").click }.to raise_unknown_object_exception
+      expect { browser.ins(title: "no_such_title").click }.to raise_unknown_object_exception
     end
   end
 

--- a/label_spec.rb
+++ b/label_spec.rb
@@ -56,7 +56,7 @@ describe "Label" do
     end
 
     it "raises UnknownObjectException if the label doesn't exist" do
-      expect { browser.label(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.label(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -66,7 +66,7 @@ describe "Label" do
     end
 
     it "raises UnknownObjectException if the label doesn't exist" do
-      expect { browser.label(index: 1337).for }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.label(index: 1337).for }.to raise_unknown_object_exception
     end
   end
 

--- a/labels_spec.rb
+++ b/labels_spec.rb
@@ -15,7 +15,7 @@ describe "Labels" do
 
   describe "#length" do
     it "returns the number of labels" do
-      expect(browser.labels.length).to eq 38
+      expect(browser.labels.length).to eq 39
     end
   end
 

--- a/li_spec.rb
+++ b/li_spec.rb
@@ -55,7 +55,7 @@ describe "Li" do
     end
 
     it "raises UnknownObjectException if the li doesn't exist" do
-      expect { browser.li(id: 'no_such_id').class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.li(id: 'no_such_id').class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -69,8 +69,8 @@ describe "Li" do
     end
 
     it "raises UnknownObjectException if the li doesn't exist" do
-      expect { browser.li(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.li(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.li(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.li(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -84,8 +84,8 @@ describe "Li" do
     end
 
     it "raises UnknownObjectException if the li doesn't exist" do
-      expect { browser.li(id: 'no_such_id').title }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.li(xpath: "//li[@id='no_such_id']").title }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.li(id: 'no_such_id').title }.to raise_unknown_object_exception
+      expect { browser.li(xpath: "//li[@id='no_such_id']").title }.to raise_unknown_object_exception
     end
   end
 
@@ -99,8 +99,8 @@ describe "Li" do
     end
 
     it "raises UnknownObjectException if the li doesn't exist" do
-      expect { browser.li(id: 'no_such_id').text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.li(:xpath , "//li[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.li(id: 'no_such_id').text }.to raise_unknown_object_exception
+      expect { browser.li(:xpath , "//li[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 

--- a/link_spec.rb
+++ b/link_spec.rb
@@ -65,7 +65,7 @@ describe "Link" do
     end
 
     it "raises an UnknownObjectException if the link doesn't exist" do
-      expect { browser.link(index: 1337).class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.link(index: 1337).class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -79,7 +79,7 @@ describe "Link" do
     end
 
     it "raises an UnknownObjectException if the link doesn't exist" do
-      expect { browser.link(index: 1337).href }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.link(index: 1337).href }.to raise_unknown_object_exception
     end
   end
 
@@ -99,7 +99,7 @@ describe "Link" do
     end
 
     it "raises an UnknownObjectException if the link doesn't exist" do
-      expect { browser.link(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.link(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -113,7 +113,7 @@ describe "Link" do
     end
 
     it "raises an UnknownObjectException if the link doesn't exist" do
-      expect { browser.link(index: 1337).text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.link(index: 1337).text }.to raise_unknown_object_exception
     end
   end
 
@@ -127,7 +127,7 @@ describe "Link" do
     end
 
     it "raises an UnknownObjectException if the link doesn't exist" do
-      expect { browser.link(index: 1337).title }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.link(index: 1337).title }.to raise_unknown_object_exception
     end
   end
 
@@ -160,7 +160,7 @@ describe "Link" do
     end
 
     it "raises an UnknownObjectException if the link doesn't exist" do
-      expect { browser.link(index: 1337).click }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.link(index: 1337).click }.to raise_unknown_object_exception
     end
 
     it "clicks a link with no text content but an img child" do

--- a/map_spec.rb
+++ b/map_spec.rb
@@ -51,8 +51,8 @@ describe "Map" do
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      expect { browser.map(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.map(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.map(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.map(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -66,8 +66,8 @@ describe "Map" do
     end
 
     it "raises UnknownObjectException if the map doesn't exist" do
-      expect { browser.map(id: "no_such_id").name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.map(index: 1337).name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.map(id: "no_such_id").name }.to raise_unknown_object_exception
+      expect { browser.map(index: 1337).name }.to raise_unknown_object_exception
     end
   end
 

--- a/ol_spec.rb
+++ b/ol_spec.rb
@@ -62,7 +62,7 @@ describe "Ol" do
     end
 
     it "raises UnknownObjectException if the ol doesn't exist" do
-      expect { browser.ol(id: 'no_such_id').class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.ol(id: 'no_such_id').class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -76,8 +76,8 @@ describe "Ol" do
     end
 
     it "raises UnknownObjectException if the ol doesn't exist" do
-      expect { browser.ol(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.ol(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.ol(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.ol(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 

--- a/option_spec.rb
+++ b/option_spec.rb
@@ -114,13 +114,13 @@ describe "Option" do
     end
 
     it "raises UnknownObjectException if the option does not exist (page context)" do
-      expect { browser.option(text: "no_such_text").select }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.option(text: /missing/).select }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.option(text: "no_such_text").select }.to raise_unknown_object_exception
+      expect { browser.option(text: /missing/).select }.to raise_unknown_object_exception
     end
 
     it "raises UnknownObjectException if the option does not exist (select_list context)" do
-      expect { browser.select_list(name: "new_user_country").option(text: "no_such_text").select }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.select_list(name: "new_user_country").option(text: /missing/).select }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.select_list(name: "new_user_country").option(text: "no_such_text").select }.to raise_unknown_object_exception
+      expect { browser.select_list(name: "new_user_country").option(text: /missing/).select }.to raise_unknown_object_exception
     end
 
     it "raises MissingWayOfFindingObjectException when given a bad 'how' (page context)" do

--- a/p_spec.rb
+++ b/p_spec.rb
@@ -55,7 +55,7 @@ describe "P" do
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      expect { browser.p(id: 'no_such_id').class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.p(id: 'no_such_id').class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -69,8 +69,8 @@ describe "P" do
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      expect { browser.p(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.p(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.p(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.p(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -84,8 +84,8 @@ describe "P" do
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      expect { browser.p(id: 'no_such_id').title }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.p(xpath: "//p[@id='no_such_id']").title }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.p(id: 'no_such_id').title }.to raise_unknown_object_exception
+      expect { browser.p(xpath: "//p[@id='no_such_id']").title }.to raise_unknown_object_exception
     end
   end
 
@@ -99,8 +99,8 @@ describe "P" do
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      expect { browser.p(id: 'no_such_id').text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.p(:xpath , "//p[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.p(id: 'no_such_id').text }.to raise_unknown_object_exception
+      expect { browser.p(:xpath , "//p[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 

--- a/pre_spec.rb
+++ b/pre_spec.rb
@@ -55,7 +55,7 @@ describe "Pre" do
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      expect { browser.pre(id: 'no_such_id').class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.pre(id: 'no_such_id').class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -69,8 +69,8 @@ describe "Pre" do
     end
 
     it "raises UnknownObjectException if the pre doesn't exist" do
-      expect { browser.pre(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.pre(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.pre(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.pre(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -84,8 +84,8 @@ describe "Pre" do
     end
 
     it "raises UnknownObjectException if the pre doesn't exist" do
-      expect { browser.pre(id: 'no_such_id').title }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.pre(xpath: "//pre[@id='no_such_id']").title }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.pre(id: 'no_such_id').title }.to raise_unknown_object_exception
+      expect { browser.pre(xpath: "//pre[@id='no_such_id']").title }.to raise_unknown_object_exception
     end
   end
 
@@ -99,8 +99,8 @@ describe "Pre" do
     end
 
     it "raises UnknownObjectException if the pre doesn't exist" do
-      expect { browser.pre(id: 'no_such_id').text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.pre(:xpath , "//pre[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.pre(id: 'no_such_id').text }.to raise_unknown_object_exception
+      expect { browser.pre(:xpath , "//pre[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 

--- a/radio_spec.rb
+++ b/radio_spec.rb
@@ -85,7 +85,7 @@ describe "Radio" do
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      expect { browser.radio(id: "no_such_id").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.radio(id: "no_such_id").class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -99,7 +99,7 @@ describe "Radio" do
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      expect { browser.radio(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.radio(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -113,7 +113,7 @@ describe "Radio" do
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      expect { browser.radio(index: 1337).name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.radio(index: 1337).name }.to raise_unknown_object_exception
     end
   end
 
@@ -127,7 +127,7 @@ describe "Radio" do
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      expect { browser.radio(index: 1337).title }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.radio(index: 1337).title }.to raise_unknown_object_exception
     end
   end
 
@@ -137,7 +137,7 @@ describe "Radio" do
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      expect { browser.radio(index: 1337).type }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.radio(index: 1337).type }.to raise_unknown_object_exception
     end
   end
 
@@ -147,7 +147,7 @@ describe "Radio" do
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      expect { browser.radio(index: 1337).value}.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.radio(index: 1337).value}.to raise_unknown_object_exception
     end
   end
 
@@ -175,8 +175,8 @@ describe "Radio" do
     end
 
     it "raises UnknownObjectException if the radio button doesn't exist" do
-      expect { browser.radio(id: "no_such_id").enabled?  }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.radio(xpath: "//input[@id='no_such_id']").enabled?  }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.radio(id: "no_such_id").enabled?  }.to raise_unknown_object_exception
+      expect { browser.radio(xpath: "//input[@id='no_such_id']").enabled?  }.to raise_unknown_object_exception
     end
   end
 
@@ -190,7 +190,7 @@ describe "Radio" do
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      expect { browser.radio(index: 1337).disabled? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.radio(index: 1337).disabled? }.to raise_unknown_object_exception
     end
   end
 
@@ -227,8 +227,8 @@ describe "Radio" do
     end
 
     it "raises UnknownObjectException if the radio button doesn't exist" do
-      expect { browser.radio(name: "no_such_name").set  }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.radio(xpath: "//input[@name='no_such_name']").set  }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.radio(name: "no_such_name").set  }.to raise_unknown_object_exception
+      expect { browser.radio(xpath: "//input[@name='no_such_name']").set  }.to raise_unknown_object_exception
     end
 
     it "raises ObjectDisabledException if the radio is disabled" do
@@ -256,8 +256,8 @@ describe "Radio" do
     end
 
     it "raises UnknownObjectException if the radio button doesn't exist" do
-      expect { browser.radio(id: "no_such_id").set?  }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.radio(xpath: "//input[@id='no_such_id']").set?  }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.radio(id: "no_such_id").set?  }.to raise_unknown_object_exception
+      expect { browser.radio(xpath: "//input[@id='no_such_id']").set?  }.to raise_unknown_object_exception
     end
   end
 

--- a/radio_spec.rb
+++ b/radio_spec.rb
@@ -232,8 +232,8 @@ describe "Radio" do
     end
 
     it "raises ObjectDisabledException if the radio is disabled" do
-      expect { browser.radio(id: "new_user_newsletter_nah").set  }.to raise_error(Watir::Exception::ObjectDisabledException)
-      expect { browser.radio(xpath: "//input[@id='new_user_newsletter_nah']").set  }.to raise_error(Watir::Exception::ObjectDisabledException )
+      expect { browser.radio(id: "new_user_newsletter_nah").set  }.to raise_object_disabled_exception
+      expect { browser.radio(xpath: "//input[@id='new_user_newsletter_nah']").set  }.to raise_object_disabled_exception
     end
   end
 

--- a/relaxed_locate_spec.rb
+++ b/relaxed_locate_spec.rb
@@ -1,0 +1,206 @@
+require File.expand_path("../spec_helper", __FILE__)
+
+module Watir
+  describe '#relaxed_locate?' do
+    not_compliant_on :not_relaxed_locate do
+      context 'when true' do
+        before :each do
+          browser.goto(WatirSpec.url_for("wait.html"))
+        end
+
+        context 'when acting on an element that is never present' do
+          it 'raises exception after timing out' do
+            begin
+              time_out = 2
+              Watir.default_timeout = time_out
+              element = browser.link(id: 'not_there')
+              start_time = ::Time.now
+              expect { element.click }.to raise_exception(Exception::UnknownObjectException)
+              expect(::Time.now - start_time).to be > time_out
+            ensure
+              Watir.default_timeout = 30
+            end
+          end
+        end
+
+        context 'when acting on an element that is already present' do
+          it 'does not wait' do
+            start_time = ::Time.now
+            expect { browser.link.click }.to_not raise_exception
+            expect(::Time.now - start_time).to be < 1
+          end
+        end
+
+        context 'when acting on an element that eventually becomes present' do
+          it 'waits to take action' do
+            start_time = ::Time.now
+            browser.a(id: 'show_bar').click
+            expect { browser.div(id: 'bar').click }.to_not raise_exception
+            expect(::Time.now - start_time).to be < Watir.default_timeout
+          end
+        end
+
+        context 'when evaluating order of failure precedence' do
+          it 'fails first for parent not existing' do
+            begin
+              Watir.default_timeout = 0
+              selector = "{:id=>\"no_parent\", :tag_name=>\"div\"}"
+              element = browser.div(id: 'no_parent').div(id: 'no_child')
+              error = Watir::Exception::UnknownObjectException
+              message = "timed out after #{Watir.default_timeout} seconds, waiting for #{selector} to be located"
+              expect { element.click }.to raise_exception(error, message)
+            ensure
+              Watir.default_timeout = 30
+            end
+          end
+
+          it 'fails for child not existing if parent exists' do
+            begin
+              Watir.default_timeout = 0
+              selector = "{:id=>\"buttons\", :tag_name=>\"div\"} --> {:id=>\"no_child\", :tag_name=>\"div\"}"
+              element = browser.div(id: 'buttons').div(id: 'no_child')
+              error = Watir::Exception::UnknownObjectException
+              message = "timed out after #{Watir.default_timeout} seconds, waiting for #{selector} to be located"
+              expect { element.click }.to raise_exception(error, message)
+            ensure
+              Watir.default_timeout = 30
+            end
+          end
+
+          it 'fails for parent not present if child exists' do
+            begin
+              Watir.default_timeout = 0.5
+              selector = "{:id=>\"also_hidden\", :tag_name=>\"div\"}"
+              element = browser.div(id: 'also_hidden').div(id: 'hidden_child')
+              error = Watir::Exception::UnknownObjectException
+              message = "element located, but timed out after #{Watir.default_timeout} seconds, waiting for true condition on #{selector}"
+              expect { element.click }.to raise_exception(error, message)
+            ensure
+              Watir.default_timeout = 30
+            end
+          end
+
+          it 'fails for child not present if parent is present' do
+            begin
+              Watir.default_timeout = 0.5
+              selector = "{:id=>\"buttons\", :tag_name=>\"div\"} --> {:id=>\"btn2\", :tag_name=>\"button\"}"
+              element = browser.div(id: 'buttons').button(id: 'btn2')
+              error = Watir::Exception::UnknownObjectException
+              message = "element located, but timed out after #{Watir.default_timeout} seconds, waiting for true condition on #{selector}"
+              expect { element.click }.to raise_exception(error, message)
+            ensure
+              Watir.default_timeout = 30
+            end
+          end
+
+          it 'fails for element not enabled if present' do
+            browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
+            begin
+              Watir.default_timeout = 0.5
+              selector = "{:id=>\"new_user\", :tag_name=>\"form\"} --> {:id=>\"good_luck\", :tag_name=>\"input or textarea\", :type=>\"(any text type)\"}"
+              element = browser.form(id: 'new_user').text_field(id: 'good_luck')
+              error = Watir::Exception::ObjectDisabledException
+              message = "element present, but timed out after #{Watir.default_timeout} seconds, waiting for #{selector} to be enabled"
+              expect { element.set('foo') }.to raise_exception(error, message)
+            ensure
+              Watir.default_timeout = 30
+            end
+          end
+
+          it 'fails for element being readonly if enabled' do
+            browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
+            begin
+              Watir.default_timeout = 0.5
+              selector = "{:id=>\"new_user\", :tag_name=>\"form\"} --> {:id=>\"new_user_code\", :tag_name=>\"input or textarea\", :type=>\"(any text type)\"}"
+              element = browser.form(id: 'new_user').text_field(id: 'new_user_code')
+              error = Watir::Exception::ObjectReadOnlyException
+              message = "element present and enabled, but timed out after #{Watir.default_timeout} seconds, waiting for #{selector} to not be readonly"
+              expect { element.set('foo') }.to raise_exception(error, message)
+            ensure
+              Watir.default_timeout = 30
+            end
+          end
+        end
+
+        it 'gives warning when rescuing for flow control' do
+          begin
+            Watir.default_timeout = 1
+            element = browser.link(id: 'not_there')
+            message = "This test has slept for the duration of the default timeout. If your test is passing, consider using Element#exists? instead of rescuing this error\n"
+            expect do
+              begin
+                element.click
+              rescue Exception::UnknownObjectException
+              end
+            end.to output(message).to_stderr
+          ensure
+            Watir.default_timeout = 30
+          end
+        end
+
+        it 'ensures all checks happen once even if time has expired' do
+          begin
+            Watir.default_timeout = -1
+            expect { browser.link.click }.to_not raise_exception
+          ensure
+            Watir.default_timeout = 30
+          end
+        end
+
+        it 'ensures that the same timeout is used for all of the calls' do
+          begin
+            Watir.default_timeout = 1
+            start_time = ::Time.now
+            browser.a(id: 'show_bar').click
+            expect { browser.div(id: 'bar').div(id: 'not_there').click }.to raise_exception
+            finish_time = ::Time.now - start_time
+            expect(finish_time).to be > Watir.default_timeout
+            expect(finish_time).to be < 2 * Watir.default_timeout
+          ensure
+            Watir.default_timeout = 30
+          end
+        end
+      end
+    end
+
+    not_compliant_on :relaxed_locate do
+      context 'when false' do
+        before :each do
+          browser.goto(WatirSpec.url_for("wait.html"))
+        end
+
+        context 'when acting on an element that is never present' do
+          it 'raises exception immediately' do
+            begin
+              time_out = 2
+              Watir.default_timeout = time_out
+              element = browser.link(id: 'not_there')
+              start_time = ::Time.now
+              expect { element.click }.to raise_exception(Exception::UnknownObjectException)
+              expect(::Time.now - start_time).to be < 1
+            ensure
+              Watir.default_timeout = 30
+            end
+          end
+        end
+
+        context 'when acting on an element that eventually becomes present' do
+          it 'raises exception immediately' do
+            start_time = ::Time.now
+            browser.a(id: 'show_bar').click
+            expect { browser.div(id: 'bar').click }.to raise_exception(Selenium::WebDriver::Error::ElementNotVisibleError)
+            expect(::Time.now - start_time).to be < 1
+          end
+        end
+
+        it 'receives a warning for using #when_present' do
+          message = /#when_present would likely be unnecessary if Watir#relaxed_locate\? were set to true/
+          browser.a(id: 'show_bar').click
+          expect do
+            browser.div(id: 'bar').when_present.click
+          end.to output(message).to_stderr
+        end
+      end
+    end
+  end
+end

--- a/select_list_spec.rb
+++ b/select_list_spec.rb
@@ -55,7 +55,7 @@ describe "SelectList" do
     end
 
     it "raises UnknownObjectException if the select list doesn't exist" do
-      expect { browser.select_list(name: 'no_such_name').class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.select_list(name: 'no_such_name').class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -65,7 +65,7 @@ describe "SelectList" do
     end
 
     it "raises UnknownObjectException if the select list doesn't exist" do
-      expect { browser.select_list(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.select_list(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -75,7 +75,7 @@ describe "SelectList" do
     end
 
     it "raises UnknownObjectException if the select list doesn't exist" do
-      expect { browser.select_list(index: 1337).name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.select_list(index: 1337).name }.to raise_unknown_object_exception
     end
   end
 
@@ -86,7 +86,7 @@ describe "SelectList" do
     end
 
     it "raises UnknownObjectException if the select list doesn't exist" do
-      expect { browser.select_list(index: 1337).multiple? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.select_list(index: 1337).multiple? }.to raise_unknown_object_exception
     end
   end
 
@@ -100,7 +100,7 @@ describe "SelectList" do
     end
 
     it "raises UnknownObjectException if the select list doesn't exist" do
-      expect { browser.select_list(index: 1337).value }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.select_list(index: 1337).value }.to raise_unknown_object_exception
     end
   end
 
@@ -124,7 +124,7 @@ describe "SelectList" do
     end
 
     it "raises UnknownObjectException if the select_list doesn't exist" do
-      expect { browser.select_list(name: 'no_such_name').enabled? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.select_list(name: 'no_such_name').enabled? }.to raise_unknown_object_exception
     end
   end
 
@@ -138,7 +138,7 @@ describe "SelectList" do
     end
 
     it "should raise UnknownObjectException when the select list does not exist" do
-      expect { browser.select_list(index: 1337).disabled? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.select_list(index: 1337).disabled? }.to raise_unknown_object_exception
     end
   end
 
@@ -160,7 +160,7 @@ describe "SelectList" do
 
   describe "#selected_options" do
     it "should raise UnknownObjectException if the select list doesn't exist" do
-      expect { browser.select_list(name: 'no_such_name').selected_options }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.select_list(name: 'no_such_name').selected_options }.to raise_unknown_object_exception
     end
 
     it "gets the currently selected item(s)" do
@@ -186,7 +186,7 @@ describe "SelectList" do
     end
 
     it "raises UnknownObjectException if the select list doesn't exist" do
-      expect { browser.select_list(name: 'no_such_name').clear }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.select_list(name: 'no_such_name').clear }.to raise_unknown_object_exception
     end
 
     not_compliant_on :safari do
@@ -244,7 +244,7 @@ describe "SelectList" do
     end
 
     it "raises UnknownObjectException if the option doesn't exist" do
-      expect { browser.select_list(name: 'new_user_country').selected?('missing_option') }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.select_list(name: 'new_user_country').selected?('missing_option') }.to raise_unknown_object_exception
     end
   end
 

--- a/select_list_spec.rb
+++ b/select_list_spec.rb
@@ -347,7 +347,7 @@ describe "SelectList" do
     end
 
     it "raises ObjectDisabledException if the option is disabled" do
-      expect { browser.select_list(name: "new_user_languages").select("Russian") }.to raise_error(Watir::Exception::ObjectDisabledException)
+      expect { browser.select_list(name: "new_user_languages").select("Russian") }.to raise_object_disabled_exception
     end
 
     it "raises a TypeError if argument is not a String, Regexp or Numeric" do

--- a/span_spec.rb
+++ b/span_spec.rb
@@ -55,7 +55,7 @@ describe "Span" do
     end
 
     it "raises UnknownObjectException if the span doesn't exist" do
-      expect { browser.span(id: 'no_such_id').class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.span(id: 'no_such_id').class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -69,8 +69,8 @@ describe "Span" do
     end
 
     it "raises UnknownObjectException if the span doesn't exist" do
-      expect { browser.span(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.span(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.span(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.span(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -84,8 +84,8 @@ describe "Span" do
     end
 
     it "raises UnknownObjectException if the span doesn't exist" do
-      expect { browser.span(id: 'no_such_id').title }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.span(xpath: "//span[@id='no_such_id']").title }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.span(id: 'no_such_id').title }.to raise_unknown_object_exception
+      expect { browser.span(xpath: "//span[@id='no_such_id']").title }.to raise_unknown_object_exception
     end
   end
 
@@ -99,8 +99,8 @@ describe "Span" do
     end
 
     it "raises UnknownObjectException if the span doesn't exist" do
-      expect { browser.span(id: 'no_such_id').text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.span(:xpath , "//span[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.span(id: 'no_such_id').text }.to raise_unknown_object_exception
+      expect { browser.span(:xpath , "//span[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 
@@ -122,8 +122,8 @@ describe "Span" do
     end
 
     it "raises UnknownObjectException if the span doesn't exist" do
-      expect { browser.span(id: "no_such_id").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.span(title: "no_such_title").click }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.span(id: "no_such_id").click }.to raise_unknown_object_exception
+      expect { browser.span(title: "no_such_title").click }.to raise_unknown_object_exception
     end
   end
 

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -22,10 +22,12 @@ end
 
 TIMING_EXCEPTIONS = { raise_unknown_object_exception: Watir::Exception::UnknownObjectException,
                       raise_no_matching_window_exception: Watir::Exception::NoMatchingWindowFoundException,
-                      raise_unknown_frame_exception: Watir::Exception::UnknownFrameException }
+                      raise_unknown_frame_exception: Watir::Exception::UnknownFrameException,
+                      raise_object_read_only_exception: Watir::Exception::ObjectReadOnlyException,
+                      raise_object_disabled_exception: Watir::Exception::ObjectDisabledException}
 
 TIMING_EXCEPTIONS.each do |matcher, exception|
-  RSpec::Matchers.define matcher do |expected|
+  RSpec::Matchers.define matcher do |_expected|
     match do |actual|
       original_timeout = Watir.default_timeout
       Watir.default_timeout = 0

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -20,3 +20,32 @@ else
   WatirSpec::Runner.execute_if_necessary
 end
 
+TIMING_EXCEPTIONS = { raise_unknown_object_exception: Watir::Exception::UnknownObjectException,
+                      raise_no_matching_window_exception: Watir::Exception::NoMatchingWindowFoundException,
+                      raise_unknown_frame_exception: Watir::Exception::UnknownFrameException }
+
+TIMING_EXCEPTIONS.each do |matcher, exception|
+  RSpec::Matchers.define matcher do |expected|
+    match do |actual|
+      original_timeout = Watir.default_timeout
+      Watir.default_timeout = 0
+      begin
+        actual.call
+        false
+      rescue exception
+        true
+      ensure
+        Watir.default_timeout = original_timeout
+      end
+    end
+
+    failure_message do |actual|
+      "expected #{exception} but nothing was raised"
+    end
+
+    def supports_block_expectations?
+      true
+    end
+  end
+end
+

--- a/strong_spec.rb
+++ b/strong_spec.rb
@@ -55,7 +55,7 @@ describe "Strong" do
     end
 
     it "raises UnknownObjectException if the element doesn't exist" do
-      expect { browser.strong(id: 'no_such_id').class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.strong(id: 'no_such_id').class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -65,8 +65,8 @@ describe "Strong" do
     end
 
     it "raises UnknownObjectException if the element doesn't exist" do
-      expect { browser.strong(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.strong(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.strong(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.strong(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -76,8 +76,8 @@ describe "Strong" do
     end
 
     it "raises UnknownObjectException if the element doesn't exist" do
-      expect { browser.strong(id: 'no_such_id').text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.strong(:xpath , "//strong[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.strong(id: 'no_such_id').text }.to raise_unknown_object_exception
+      expect { browser.strong(:xpath , "//strong[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 

--- a/text_field_spec.rb
+++ b/text_field_spec.rb
@@ -213,11 +213,11 @@ describe "TextField" do
     end
 
     it "raises ObjectReadOnlyException if the object is read only" do
-      expect { browser.text_field(id: "new_user_code").append("Append This") }.to raise_error(Watir::Exception::ObjectReadOnlyException)
+      expect { browser.text_field(id: "new_user_code").append("Append This") }.to raise_object_read_only_exception
     end
 
     it "raises ObjectDisabledException if the object is disabled" do
-      expect { browser.text_field(name: "new_user_species").append("Append This") }.to raise_error(Watir::Exception::ObjectDisabledException)
+      expect { browser.text_field(name: "new_user_species").append("Append This") }.to raise_object_disabled_exception
     end
 
     it "raises UnknownObjectException if the object doesn't exist" do
@@ -239,7 +239,7 @@ describe "TextField" do
 
     bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1200366", :firefox do
       it "raises ObjectReadOnlyException if the object is read only" do
-        expect { browser.text_field(id: "new_user_code").clear }.to raise_error(Watir::Exception::ObjectReadOnlyException)
+        expect { browser.text_field(id: "new_user_code").clear }.to raise_object_read_only_exception
       end
     end
   end

--- a/text_field_spec.rb
+++ b/text_field_spec.rb
@@ -88,7 +88,7 @@ describe "TextField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -98,7 +98,7 @@ describe "TextField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(index: 1337).name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(index: 1337).name }.to raise_unknown_object_exception
     end
   end
 
@@ -108,7 +108,7 @@ describe "TextField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(index: 1337).title }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(index: 1337).title }.to raise_unknown_object_exception
     end
   end
 
@@ -126,7 +126,7 @@ describe "TextField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(index: 1337).type }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(index: 1337).type }.to raise_unknown_object_exception
     end
   end
 
@@ -138,7 +138,7 @@ describe "TextField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(index: 1337).value }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(index: 1337).value }.to raise_unknown_object_exception
     end
   end
 
@@ -165,7 +165,7 @@ describe "TextField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(id: "no_such_id").enabled? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(id: "no_such_id").enabled? }.to raise_unknown_object_exception
     end
   end
 
@@ -179,7 +179,7 @@ describe "TextField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(index: 1337).disabled? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(index: 1337).disabled? }.to raise_unknown_object_exception
     end
   end
 
@@ -196,7 +196,7 @@ describe "TextField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(id: 'no_such_id').readonly? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(id: 'no_such_id').readonly? }.to raise_unknown_object_exception
     end
   end
 
@@ -221,7 +221,7 @@ describe "TextField" do
     end
 
     it "raises UnknownObjectException if the object doesn't exist" do
-      expect { browser.text_field(name: "no_such_name").append("Append This") }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(name: "no_such_name").append("Append This") }.to raise_unknown_object_exception
     end
   end
 
@@ -234,7 +234,7 @@ describe "TextField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(id: "no_such_id").clear }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(id: "no_such_id").clear }.to raise_unknown_object_exception
     end
 
     bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1200366", :firefox do
@@ -261,7 +261,7 @@ describe "TextField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(name: "no_such_name").value = 'yo' }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(name: "no_such_name").value = 'yo' }.to raise_unknown_object_exception
     end
   end
 
@@ -297,7 +297,7 @@ describe "TextField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(id: "no_such_id").set('secret') }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(id: "no_such_id").set('secret') }.to raise_unknown_object_exception
     end
   end
 end

--- a/text_fields_spec.rb
+++ b/text_fields_spec.rb
@@ -15,7 +15,7 @@ describe "TextFields" do
 
   describe "#length" do
     it "returns the number of text fields" do
-      expect(browser.text_fields.length).to eq 20
+      expect(browser.text_fields.length).to eq 21
     end
   end
 

--- a/ul_spec.rb
+++ b/ul_spec.rb
@@ -51,7 +51,7 @@ describe "Ul" do
     end
 
     it "raises UnknownObjectException if the ul doesn't exist" do
-      expect { browser.ul(id: 'no_such_id').class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.ul(id: 'no_such_id').class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -65,8 +65,8 @@ describe "Ul" do
     end
 
     it "raises UnknownObjectException if the ul doesn't exist" do
-      expect { browser.ul(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.ul(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.ul(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.ul(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 

--- a/wait_spec.rb
+++ b/wait_spec.rb
@@ -4,59 +4,66 @@ require File.expand_path("../spec_helper", __FILE__)
 not_compliant_on :safari do
   describe Watir::Wait do
     describe "#until" do
-      it "returns result of block if truthy" do
-        result = 'catter'
-        expect(Wait.until(0.5) { result }).to be result
-      end
-
       it "waits until the block returns true" do
-        expect(Wait.until(0.5) { true }).to be true
+        Wait.until(timeout: 0.5) { @result = true }
+        expect(@result).to be true
       end
 
       it "executes block if timeout is zero" do
-        expect(Wait.until(0) { true }).to be true
+        Wait.until(timeout: 0) { @result = true }
+        expect(@result).to be true
       end
 
       it "times out" do
-        expect {Wait.until(0.5) { false }}.to raise_error(Watir::Wait::TimeoutError)
+        expect {Wait.until(timeout: 0.5) { false }}.to raise_error(Watir::Wait::TimeoutError)
       end
 
       it "times out with a custom message" do
         expect {
-          Wait.until(0.5, "oops") { false }
+          Wait.until(timeout: 0.5, message: "oops") { false }
         }.to raise_error(Watir::Wait::TimeoutError, "timed out after 0.5 seconds, oops")
       end
 
       it "uses timer for waiting" do
         timer = Wait.timer
         expect(timer).to receive(:wait).with(0.5).and_call_original
-        Wait.until(0.5) { true }
+        Wait.until(timeout: 0.5) { true }
+      end
+
+      it "ordered pairs are deprecated" do
+        message = /Instead of passing arguments into Wait#until method, use keywords/
+        expect { Wait.until(0) { true } }.to output(message).to_stderr
       end
     end
 
     describe "#while" do
       it "waits while the block returns true" do
-        expect(Wait.while(0.5) { false }).to be_nil
+        expect(Wait.while(timeout: 0.5) { false }).to be_nil
       end
 
       it "executes block if timeout is zero" do
-        expect(Wait.while(0) { false }).to be_nil
+        expect(Wait.while(timeout: 0) { false }).to be_nil
       end
 
       it "times out" do
-        expect {Wait.while(0.5) { true }}.to raise_error(Watir::Wait::TimeoutError)
+        expect {Wait.while(timeout: 0.5) { true }}.to raise_error(Watir::Wait::TimeoutError)
       end
 
       it "times out with a custom message" do
         expect {
-          Wait.while(0.5, "oops") { true }
+          Wait.while(timeout: 0.5, message: "oops") { true }
         }.to raise_error(Watir::Wait::TimeoutError, "timed out after 0.5 seconds, oops")
       end
 
       it "uses timer for waiting" do
         timer = Wait.timer
         expect(timer).to receive(:wait).with(0.5).and_call_original
-        Wait.while(0.5) { false }
+        Wait.while(timeout: 0.5) { false }
+      end
+
+      it "ordered pairs are deprecated" do
+        message = /Instead of passing arguments into Wait#while method, use keywords/
+        expect { Wait.while(0) { false } }.to output(message).to_stderr
       end
     end
 
@@ -75,6 +82,28 @@ not_compliant_on :safari do
         expect(Wait.timer).to eq(timer)
       end
     end
+
+    describe "#when_present" do
+      it 'receives a warning for using #when_present' do
+        browser.goto(WatirSpec.url_for("wait.html"))
+
+        message = /when_present has been deprecated; use #wait_until_present if a wait is still needed/
+        browser.a(id: 'show_bar').click
+        expect do
+          browser.div(id: 'bar').when_present.click
+        end.to output(message).to_stderr
+      end
+
+      it 'receives a warning for passing block to #when_present' do
+        browser.goto(WatirSpec.url_for("wait.html"))
+
+        message = /do not pass a block to take actions after a wait/
+        browser.a(id: 'show_bar').click
+        expect do
+          browser.div(id: 'bar').when_present {  }
+        end.to output(message).to_stderr
+      end
+    end
   end
 
   describe Watir::Element do
@@ -82,134 +111,39 @@ not_compliant_on :safari do
       browser.goto WatirSpec.url_for("wait.html")
     end
 
-    describe "#when_present" do
-      it "yields when the element becomes present" do
-        called = false
-
-        browser.a(id: 'show_bar').click
-        browser.div(id: 'bar').when_present(2) { called = true }
-
-        expect(called).to be true
-      end
-
-      it "invokes subsequent method calls when the element becomes present" do
-        browser.a(id: 'show_bar').click
-
-        bar = browser.div(id: 'bar')
-        bar.when_present(2).click
-        expect(bar.text).to eq "changed"
-      end
-
-      it "times out when given a block" do
-        expect { browser.div(id: 'bar').when_present(1) {}}.to raise_error(Watir::Wait::TimeoutError)
-      end
-
-      it "times out when not given a block" do
-        expect { browser.div(id: 'bar').when_present(1).click }.to raise_error(Watir::Wait::TimeoutError,
-          /^timed out after 1 seconds, waiting for (\{:id=>"bar", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"bar"\}) to become present$/
-        )
-      end
-
-      it "responds to Element methods" do
-        decorator = browser.div.when_present
-
-        expect(decorator).to respond_to(:exist?)
-        expect(decorator).to respond_to(:present?)
-        expect(decorator).to respond_to(:click)
-      end
-
-      it "delegates present? to element" do
-        Object.class_eval do
-          def present?
-            false
-          end
-        end
-        element = browser.a(id: "show_bar").when_present(1)
-        expect(element).to be_present
-      end
-
-      it "processes before calling present?" do
-        browser.a(id: 'show_bar').click
-        expect(browser.div(id: 'bar').when_present.present?).to be true
-      end
-
-    end
-
-    describe "#when_enabled" do
-      it "yields when the element becomes enabled" do
-        called = false
-
-        browser.a(id: 'enable_btn').click
-        browser.button(id: 'btn').when_enabled(2) { called = true }
-
-        expect(called).to be true
-      end
-
-      it "invokes subsequent method calls when the element becomes enabled" do
-        browser.a(id: 'enable_btn').click
-
-        btn = browser.button(id: 'btn')
-        btn.when_enabled(2).click
-        expect(btn.disabled?).to be true
-      end
-
-      it "times out when given a block" do
-        expect { browser.button(id: 'btn').when_enabled(1) {}}.to raise_error(Watir::Wait::TimeoutError)
-      end
-
-      it "times out when not given a block" do
-        expect { browser.button(id: 'btn').when_enabled(1).click }.to raise_error(Watir::Wait::TimeoutError,
-          /^timed out after 1 seconds, waiting for (\{:id=>"btn", :tag_name=>"button"\}|\{:tag_name=>"button", :id=>"btn"\}) to become enabled$/
-        )
-      end
-
-      it "times out when not given a block" do
-        expect { browser.button(id: 'btn').when_enabled(1).click }.to raise_error(Watir::Wait::TimeoutError,
-          /timed out after 1 seconds, waiting for {:id=>"btn", :tag_name=>"button"} to become enabled$/
-        )
-      end
-
-      it "responds to Element methods" do
-        decorator = browser.button.when_enabled
-
-        expect(decorator).to respond_to(:exist?)
-        expect(decorator).to respond_to(:present?)
-        expect(decorator).to respond_to(:click)
-      end
-
-      it "can be chained with #when_present" do
-        browser.a(id: 'show_and_enable_btn').click
-        browser.button(id: 'btn2').when_present(1).when_enabled(1).click
-
-        expect(browser.button(id: 'btn2')).to exist
-        expect(browser.button(id: 'btn2')).to be_enabled
-      end
-    end
-
     describe "#wait_until_present" do
       it "it waits until the element appears" do
         browser.a(id: 'show_bar').click
-        expect { browser.div(id: 'bar').wait_until_present(5) }.to_not raise_exception
+        expect { browser.div(id: 'bar').wait_until_present(timeout: 5) }.to_not raise_exception
       end
 
       it "times out if the element doesn't appear" do
-        expect { browser.div(id: 'bar').wait_until_present(1) }.to raise_error(Watir::Wait::TimeoutError,
-          /^timed out after 1 seconds, waiting for (\{:id=>"bar", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"bar"\}) to become present$/
-        )
+        message = /^timed out after 1 seconds, waiting for true condition on (\{:id=>"bar", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"bar"\})$/
+        expect { browser.div(id: 'bar').wait_until_present(timeout: 1) }.to raise_error(Watir::Wait::TimeoutError, message)
       end
 
+      it "ordered pairs are deprecated" do
+        browser.a(id: 'show_bar').click
+        message = /Instead of passing arguments into #wait_until_present method, use keywords/
+        expect { browser.div(id: 'bar').wait_until_present(5) }.to output(message).to_stderr
+      end
     end
 
     describe "#wait_while_present" do
       it "waits until the element disappears" do
         browser.a(id: 'hide_foo').click
-        expect { browser.div(id: 'foo').wait_while_present(1) }.to_not raise_exception
+        expect { browser.div(id: 'foo').wait_while_present(timeout: 1) }.to_not raise_exception
       end
 
       it "times out if the element doesn't disappear" do
-        expect { browser.div(id: 'foo').wait_while_present(1) }.to raise_error(Watir::Wait::TimeoutError,
-          /^timed out after 1 seconds, waiting for (\{:id=>"foo", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"foo"\}) to disappear$/
-        )
+        message = /^timed out after 1 seconds, waiting for false condition on (\{:id=>"foo", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"foo"\})$/
+        expect { browser.div(id: 'foo').wait_while_present(timeout: 1) }.to raise_error(Watir::Wait::TimeoutError, message)
+      end
+
+      it "ordered pairs are deprecated" do
+        browser.a(id: 'hide_foo').click
+        message = /Instead of passing arguments into #wait_while_present method, use keywords/
+        expect { browser.div(id: 'foo').wait_while_present(5) }.to output(message).to_stderr
       end
     end
 
@@ -218,21 +152,76 @@ not_compliant_on :safari do
         stale_element = browser.div(id: 'foo')
         stale_element.exists?
         browser.refresh
-        expect { stale_element.wait_until_stale(1) }.to_not raise_exception
+        expect { stale_element.wait_until_stale(timeout: 1) }.to_not raise_exception
       end
 
       it "times out if the element doesn't go stale" do
-
+        message = /^timed out after 1 seconds, waiting for true condition on (\{:id=>"foo", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"foo"\})$/
         element = browser.div(id: 'foo')
         element.exists?
-        expect { element.wait_until_stale(1) }.to raise_error(Watir::Wait::TimeoutError,
-                                                              /^timed out after 1 seconds, waiting for (\{:id=>"foo", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"foo"\}) to become stale$/
-        )
+        expect { element.wait_until_stale(timeout: 1) }.to raise_error(Watir::Wait::TimeoutError, message)
+      end
+    end
+
+    describe "#wait_until" do
+      it "returns element for additional actions" do
+        element = browser.div(id: 'foo')
+        expect(element.wait_until(&:exist?)).to eq element
+      end
+
+      it "accepts self in block" do
+        element = browser.div(id: 'bar')
+        browser.a(id: 'show_bar').click
+        expect { element.wait_until { |el| el.text == 'bar' } }.to_not raise_exception
+      end
+
+      it "accepts any values in block" do
+        element = browser.div(id: 'bar')
+        expect { element.wait_until { true } }.to_not raise_exception
+      end
+
+      it "accepts just a timeout parameter" do
+        element = browser.div(id: 'bar')
+        expect { element.wait_until(timeout: 0) { true } }.to_not raise_exception
+      end
+
+      it "accepts just a message parameter" do
+        element = browser.div(id: 'bar')
+        expect { element.wait_until(message: 'no') { true } }.to_not raise_exception
+      end
+    end
+
+    describe "#wait_while" do
+      it "returns element for additional actions" do
+        element = browser.div(id: 'foo')
+        browser.a(id: 'hide_foo').click
+        expect(element.wait_while(&:present?)).to eq element
+      end
+
+      it "accepts self in block" do
+        element = browser.div(id: 'foo')
+        browser.a(id: 'hide_foo').click
+        expect { element.wait_while { |el| el.text == 'foo' } }.to_not raise_exception
+      end
+
+      it "accepts any values in block" do
+        element = browser.div(id: 'foo')
+        expect { element.wait_while { false } }.to_not raise_exception
+      end
+
+      it "accepts just a timeout parameter" do
+        element = browser.div(id: 'foo')
+        expect { element.wait_while(timeout: 0) { false } }.to_not raise_exception
+      end
+
+      it "accepts just a message parameter" do
+        element = browser.div(id: 'foo')
+        expect { element.wait_while(message: 'no') { false } }.to_not raise_exception
       end
     end
   end
 
-  describe "Watir.default_timeout" do
+  describe "Watir#default_timeout" do
     before do
       Watir.default_timeout = 1
 
@@ -254,12 +243,6 @@ not_compliant_on :safari do
       it "is used by Wait#while" do
         expect {
           Wait.while { true }
-        }.to raise_error(Watir::Wait::TimeoutError)
-      end
-
-      it "is used by Element#when_present" do
-        expect {
-          browser.div(id: 'bar').when_present.click
         }.to raise_error(Watir::Wait::TimeoutError)
       end
 

--- a/window_switching_spec.rb
+++ b/window_switching_spec.rb
@@ -81,15 +81,15 @@ not_compliant_on :safari do
       end
 
       it "raises a NoMatchingWindowFoundException error if no window matches the selector" do
-        expect { browser.window(title: "noop").use }.to raise_error(Watir::Exception::NoMatchingWindowFoundException)
+        expect { browser.window(title: "noop").use }.to raise_no_matching_window_exception
       end
 
       it "raises a NoMatchingWindowFoundException error if there's no window at the given index" do
-        expect { browser.window(index: 100).use }.to raise_error(Watir::Exception::NoMatchingWindowFoundException)
+        expect { browser.window(index: 100).use }.to raise_no_matching_window_exception
       end
 
       it "raises NoMatchingWindowFoundException error when attempting to use a window with an incorrect handle" do
-        expect { browser.window(handle: 'bar').use }.to raise_error(Watir::Exception::NoMatchingWindowFoundException)
+        expect { browser.window(handle: 'bar').use }.to raise_no_matching_window_exception
       end
     end
   end
@@ -261,7 +261,7 @@ not_compliant_on :safari do
             original_window = browser.window
             browser.window(index: 1).use
             original_window.close
-            expect { original_window.use }.to raise_error(Watir::Exception::NoMatchingWindowFoundException)
+            expect { original_window.use }.to raise_no_matching_window_exception
           end
 
           bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1223277", :firefox do
@@ -269,7 +269,7 @@ not_compliant_on :safari do
               browser.window(title: "closeable window").use
               browser.a(id: "close").click
               Watir::Wait.until { browser.windows.size == 1 }
-              expect { browser.window.use }.to raise_error(Watir::Exception::NoMatchingWindowFoundException)
+              expect { browser.window.use }.to raise_no_matching_window_exception
             end
           end
         end

--- a/window_switching_spec.rb
+++ b/window_switching_spec.rb
@@ -185,24 +185,6 @@ not_compliant_on :safari do
           expect(win1).to_not eq win2
         end
       end
-
-      describe "#when_present" do
-        it "waits until the window is present" do
-          # TODO: improve this spec.
-          did_yield = false
-          browser.window(title: "closeable window").when_present do
-            did_yield = true
-          end
-
-          expect(did_yield).to be true
-        end
-
-        it "times out waiting for a non-present window" do
-          expect {
-            browser.window(title: "noop").wait_until_present(0.5)
-          }.to raise_error(Wait::TimeoutError)
-        end
-      end
     end
 
     context "with a closed window" do


### PR DESCRIPTION
I had to create a custom matcher to turn off the auto-waits, since many of these tests are functioning more as unit tests of the code and do not need the auto-waits to demonstrate their functionality.
