### PR TITLE
id should still be validated with the tag name

### DIFF
--- a/wait_spec.rb
+++ b/wait_spec.rb
@@ -215,7 +215,7 @@ not_compliant_on :safari do
 
     describe "#wait_until_stale" do
       it "waits until the element disappears" do
-        stale_element = browser.a(id: 'foo')
+        stale_element = browser.div(id: 'foo')
         stale_element.exists?
         browser.refresh
         expect { stale_element.wait_until_stale(1) }.to_not raise_exception


### PR DESCRIPTION
this used the wrong tag_name but passed because the id worked with any tag name before.
